### PR TITLE
Expose TargetObject from API.Events.OnSpellCast

### DIFF
--- a/src/main/NWN/API/Events/Native/SpellEvents/OnSpellCast.cs
+++ b/src/main/NWN/API/Events/Native/SpellEvents/OnSpellCast.cs
@@ -16,6 +16,8 @@ namespace NWN.API.Events
 
     public Vector3 TargetPosition { get; private init; }
 
+    public NwGameObject TargetObject { get; private init; }
+
     public int ClassIndex { get; private init; }
 
     public NwItem Item { get; private init; }
@@ -51,6 +53,7 @@ namespace NWN.API.Events
           Caster = gameObject.m_idSelf.ToNwObject<NwCreature>(),
           Spell = (Spell)nSpellId,
           TargetPosition = targetPosition,
+          TargetObject = oidTarget.ToNwObject<NwGameObject>(),
           ClassIndex = nMultiClass,
           Item = itemObj.ToNwObject<NwItem>(),
           SpellCountered = bSpellCountered.ToBool(),

--- a/src/main/NWN/Services/ResourceManager/ResourceManager.cs
+++ b/src/main/NWN/Services/ResourceManager/ResourceManager.cs
@@ -113,7 +113,10 @@ namespace NWN.Services
 
     void IDisposable.Dispose()
     {
-      Directory.Delete(EnvironmentConfig.ResourcePath, true);
+      if (Directory.Exists(EnvironmentConfig.ResourcePath))
+      {
+        Directory.Delete(EnvironmentConfig.ResourcePath, true);
+      }
     }
   }
 }


### PR DESCRIPTION
I assume the property was simply forgotten. Tested OK locally.