### PR TITLE
Implement Weapon Service

### DIFF
--- a/NWN.Anvil.csproj.DotSettings
+++ b/NWN.Anvil.csproj.DotSettings
@@ -134,4 +134,5 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Cnwn_005Cservices_005Cservices_005Cbindings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Cnwn_005Cservices_005Ctime/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Cnwn_005Cservices_005Ctwodimarray/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Cnwn_005Cservices_005Cweapon/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Cplugins/@EntryIndexedValue">False</s:Boolean></wpf:ResourceDictionary>

--- a/src/main/NWN/API/Constants/CombatMode.cs
+++ b/src/main/NWN/API/Constants/CombatMode.cs
@@ -4,6 +4,7 @@ namespace NWN.API.Constants
 {
   public enum CombatMode
   {
+    None = NWScript.COMBAT_MODE_INVALID,
     Invalid = NWScript.COMBAT_MODE_INVALID,
     Parry = NWScript.COMBAT_MODE_PARRY,
     PowerAttack = NWScript.COMBAT_MODE_POWER_ATTACK,

--- a/src/main/NWN/API/Events/Native/CombatEvents/ForceNewModeOverride.cs
+++ b/src/main/NWN/API/Events/Native/CombatEvents/ForceNewModeOverride.cs
@@ -1,0 +1,9 @@
+namespace NWN.API.Events
+{
+  public enum ForceNewModeOverride
+  {
+    None,
+    Force,
+    DontForce,
+  }
+}

--- a/src/main/NWN/API/Events/Native/CombatEvents/OnCombatModeToggle.cs
+++ b/src/main/NWN/API/Events/Native/CombatEvents/OnCombatModeToggle.cs
@@ -1,0 +1,63 @@
+using System.Runtime.InteropServices;
+using NWN.Native.API;
+using NWN.Services;
+using CombatMode = NWN.API.Constants.CombatMode;
+
+namespace NWN.API.Events
+{
+  public sealed class OnCombatModeToggle : IEvent
+  {
+    public NwCreature Creature { get; private init; }
+
+    public CombatMode NewMode { get; set; }
+
+    public bool ForceNewMode { get; private init; }
+
+    public ForceNewModeOverride ForceNewModeOverride { get; set; }
+
+    public bool PreventToggle { get; set; }
+
+    NwObject IEvent.Context => Creature;
+
+    internal sealed unsafe class Factory : SingleHookEventFactory<Factory.SetCombatModeHook>
+    {
+      internal delegate void SetCombatModeHook(void* pCreature, byte nNewMode, int bForceNewMode);
+
+      protected override FunctionHook<SetCombatModeHook> RequestHook()
+      {
+        delegate* unmanaged<void*, byte, int, void> pHook = &OnSetCombatMode;
+        return HookService.RequestHook<SetCombatModeHook>(pHook, FunctionsLinux._ZN12CNWSCreature13SetCombatModeEhi, HookOrder.Early);
+      }
+
+      [UnmanagedCallersOnly]
+      private static void OnSetCombatMode(void* pCreature, byte nNewMode, int bForceNewMode)
+      {
+        CNWSCreature creature = CNWSCreature.FromPointer(pCreature);
+        if (creature == null)
+        {
+          Hook.CallOriginal(pCreature, nNewMode, bForceNewMode);
+          return;
+        }
+
+        OnCombatModeToggle eventData = ProcessEvent(new OnCombatModeToggle
+        {
+          Creature = creature.ToNwObject<NwCreature>(),
+          NewMode = (CombatMode)nNewMode,
+          ForceNewMode = bForceNewMode.ToBool(),
+        });
+
+        bForceNewMode = eventData.ForceNewModeOverride switch
+        {
+          ForceNewModeOverride.Force => true.ToInt(),
+          ForceNewModeOverride.DontForce => false.ToInt(),
+          _ => bForceNewMode,
+        };
+
+        if (!eventData.PreventToggle)
+        {
+          Hook.CallOriginal(pCreature, (byte)eventData.NewMode, bForceNewMode);
+        }
+      }
+    }
+  }
+}

--- a/src/main/NWN/Services/Weapon/DevastatingCriticalData.cs
+++ b/src/main/NWN/Services/Weapon/DevastatingCriticalData.cs
@@ -1,0 +1,12 @@
+using NWN.API;
+
+namespace NWN.Services
+{
+  public sealed class DevastatingCriticalData
+  {
+    public readonly NwItem Weapon;
+    public readonly NwGameObject Target;
+    public int Damage;
+    public bool Bypass;
+  }
+}

--- a/src/main/NWN/Services/Weapon/DevastatingCriticalData.cs
+++ b/src/main/NWN/Services/Weapon/DevastatingCriticalData.cs
@@ -5,8 +5,11 @@ namespace NWN.Services
   public sealed class DevastatingCriticalData
   {
     public NwItem Weapon { get; init; }
+
     public NwGameObject Target { get; init; }
+
     public int Damage { get; set; }
+
     public bool Bypass { get; set; }
   }
 }

--- a/src/main/NWN/Services/Weapon/DevastatingCriticalData.cs
+++ b/src/main/NWN/Services/Weapon/DevastatingCriticalData.cs
@@ -4,9 +4,9 @@ namespace NWN.Services
 {
   public sealed class DevastatingCriticalData
   {
-    public readonly NwItem Weapon;
-    public readonly NwGameObject Target;
-    public int Damage;
-    public bool Bypass;
+    public NwItem Weapon { get; init; }
+    public NwGameObject Target { get; init; }
+    public int Damage { get; set; }
+    public bool Bypass { get; set; }
   }
 }

--- a/src/main/NWN/Services/Weapon/MaxRangedAttackDistanceOverride.cs
+++ b/src/main/NWN/Services/Weapon/MaxRangedAttackDistanceOverride.cs
@@ -1,0 +1,8 @@
+namespace NWN.Services
+{
+  public struct MaxRangedAttackDistanceOverride
+  {
+    public float MaxRangedAttackDistance;
+    public float MaxRangedPassiveAttackDistance;
+  }
+}

--- a/src/main/NWN/Services/Weapon/WeaponService.cs
+++ b/src/main/NWN/Services/Weapon/WeaponService.cs
@@ -98,7 +98,25 @@ namespace NWN.Services
 
     private int OnGetWeaponFocus(void* pStats, void* pWeapon)
     {
-      throw new NotImplementedException();
+      CNWSCreatureStats stats = new CNWSCreatureStats(pStats, false);
+      uint weaponType = pWeapon == null ? (uint)BaseItem.Gloves : new CNWSItem(pWeapon, false).m_nBaseItem;
+
+      bool hasApplicableFeat = false;
+      bool applicableFeatExists = weaponFocusMap.TryGetValue(weaponType, out HashSet<ushort> types);
+
+      if (applicableFeatExists)
+      {
+        foreach (ushort feat in types)
+        {
+          hasApplicableFeat = stats.HasFeat(feat).ToBool() || feat == (ushort)Feat.WeaponFocus_Creature && stats.HasFeat((ushort)Feat.WeaponFocus_UnarmedStrike).ToBool();
+          if (hasApplicableFeat)
+          {
+            break;
+          }
+        }
+      }
+
+      return applicableFeatExists && hasApplicableFeat ? 1 : getWeaponFocusHook.CallOriginal(pStats, pWeapon);
     }
 
     private int OnGetEpicWeaponFocus(void* pStats, void* pWeapon)

--- a/src/main/NWN/Services/Weapon/WeaponService.cs
+++ b/src/main/NWN/Services/Weapon/WeaponService.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using NWN.API;
+using NWN.Native.API;
+
+namespace NWN.Services
+{
+  [ServiceBinding(typeof(WeaponService))]
+  [ServiceBindingOptions(Lazy = true)]
+  public sealed unsafe class WeaponService
+  {
+    private readonly HookService hookService;
+
+    private delegate int GetWeaponFocusHook(void* pStats, void* pWeapon);
+    private delegate int GetEpicWeaponFocusHook(void* pStats, void* pWeapon);
+    private delegate int GetWeaponFinesseHook(void* pStats, void* pWeapon);
+    private delegate int GetWeaponImprovedCriticalHook(void* pStats, void* pWeapon);
+    private delegate int GetEpicWeaponOverwhelmingCriticalHook(void* pStats, void* pWeapon);
+    private delegate int GetEpicWeaponDevastatingCriticalHook(void* pStats, void* pWeapon);
+    private delegate int GetWeaponSpecializationHook(void* pStats, void* pWeapon);
+    private delegate int GetEpicWeaponSpecializationHook(void* pStats, void* pWeapon);
+    private delegate int GetIsWeaponOfChoiceHook(void* pStats, uint nBaseItem);
+    private delegate int GetDamageBonusHook(void* pStats, void* pCreature, int bOffHand);
+    private delegate int GetMeleeDamageBonusHook(void* pStats, int bOffHand, byte nCreatureWeaponIndex);
+    private delegate int GetRangedDamageBonusHook(void* pStats);
+    private delegate int GetMeleeAttackBonusHook(void* pStats, int bOffHand, int bIncludeBase, int bTouchAttack);
+    private delegate int GetRangedAttackBonusHook(void* pStats, int bIncludeBase, int bTouchAttack);
+    private delegate int GetAttackModifierVersusHook(void* pStats, void* pCreature);
+    private delegate int GetUseMonkAttackTablesHook(void* pStats, int bForceUnarmed);
+
+    private delegate int ToggleModeHook(void* pCreature, byte nMode);
+
+    private FunctionHook<GetWeaponFocusHook> getWeaponFocusHook;
+    private FunctionHook<GetEpicWeaponFocusHook> getEpicWeaponFocusHook;
+    private FunctionHook<GetWeaponFinesseHook> getWeaponFinesseHook;
+    private FunctionHook<GetWeaponImprovedCriticalHook> getWeaponImprovedCriticalHook;
+    private FunctionHook<GetEpicWeaponOverwhelmingCriticalHook> getEpicWeaponOverwhelmingCriticalHook;
+    private FunctionHook<GetEpicWeaponDevastatingCriticalHook> getEpicWeaponDevastatingCriticalHook;
+    private FunctionHook<GetWeaponSpecializationHook> getWeaponSpecializationHook;
+    private FunctionHook<GetEpicWeaponSpecializationHook> getEpicWeaponSpecializationHook;
+    private FunctionHook<GetIsWeaponOfChoiceHook> getIsWeaponOfChoiceHook;
+    private FunctionHook<GetDamageBonusHook> getDamageBonusHook;
+    private FunctionHook<GetMeleeDamageBonusHook> getMeleeDamageBonusHook;
+    private FunctionHook<GetRangedDamageBonusHook> getRangedDamageBonusHook;
+    private FunctionHook<GetMeleeAttackBonusHook> getMeleeAttackBonusHook;
+    private FunctionHook<GetRangedAttackBonusHook> getRangedAttackBonusHook;
+    private FunctionHook<GetAttackModifierVersusHook> getAttackModifierVersusHook;
+    private FunctionHook<GetUseMonkAttackTablesHook> getUseMonkAttackTablesHook;
+    private FunctionHook<ToggleModeHook> toggleModeHook;
+
+    private Dictionary<uint, HashSet<ushort>> weaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
+    private Dictionary<uint, HashSet<ushort>> epicWeaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
+    private Dictionary<uint, byte> weaponFinesseSizeMap = new Dictionary<uint, byte>();
+    private Dictionary<uint, HashSet<ushort>> weaponImprovedCriticalMap = new Dictionary<uint, HashSet<ushort>>();
+    private Dictionary<uint, HashSet<ushort>> weaponSpecializationMap = new Dictionary<uint, HashSet<ushort>>();
+    private Dictionary<uint, HashSet<ushort>> epicWeaponSpecializationMap = new Dictionary<uint, HashSet<ushort>>();
+    private Dictionary<uint, HashSet<ushort>> epicWeaponOverwhelmingCriticalMap = new Dictionary<uint, HashSet<ushort>>();
+    private Dictionary<uint, HashSet<ushort>> epicWeaponDevastatingCriticalMap = new Dictionary<uint, HashSet<ushort>>();
+    private Dictionary<uint, HashSet<ushort>> weaponOfChoiceMap = new Dictionary<uint, HashSet<ushort>>();
+    private Dictionary<uint, HashSet<ushort>> greaterWeaponSpecializationMap = new Dictionary<uint, HashSet<ushort>>();
+    private Dictionary<uint, HashSet<ushort>> greaterWeaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
+
+    private HashSet<uint> weaponUnarmedSet = new HashSet<uint>();
+    private HashSet<uint> monkWeaponSet = new HashSet<uint>();
+
+    private DevastatingCriticalData dcData;
+    private Action<DevastatingCriticalData> dcCallback;
+
+    private int greaterFocusAttackBonus = 1;
+    private int greaeterWeaponSpecializationDamageBonus = 2;
+    private bool gaSling = false;
+
+    private Dictionary<uint, MaxRangedAttackDistanceOverride> maxRangedAttackDistanceOverrideMap = new Dictionary<uint, MaxRangedAttackDistanceOverride>();
+
+    public WeaponService(HookService hookService)
+    {
+      this.hookService = hookService;
+
+      getWeaponFocusHook = hookService.RequestHook<GetWeaponFocusHook>(OnGetWeaponFocus, FunctionsLinux._ZN17CNWSCreatureStats14GetWeaponFocusEP8CNWSItem, HookOrder.Late);
+      getEpicWeaponFocusHook = hookService.RequestHook<GetEpicWeaponFocusHook>(OnGetEpicWeaponFocus, FunctionsLinux._ZN17CNWSCreatureStats18GetEpicWeaponFocusEP8CNWSItem, HookOrder.Late);
+      getWeaponFinesseHook = hookService.RequestHook<GetWeaponFinesseHook>(OnGetWeaponFinesse, FunctionsLinux._ZN17CNWSCreatureStats16GetWeaponFinesseEP8CNWSItem, HookOrder.Final);
+      getWeaponImprovedCriticalHook = hookService.RequestHook<GetWeaponImprovedCriticalHook>(OnGetWeaponImprovedCritical, FunctionsLinux._ZN17CNWSCreatureStats25GetWeaponImprovedCriticalEP8CNWSItem, HookOrder.Late);
+      getEpicWeaponOverwhelmingCriticalHook = hookService.RequestHook<GetEpicWeaponOverwhelmingCriticalHook>(OnGetEpicWeaponOverwhelmingCritical, FunctionsLinux._ZN17CNWSCreatureStats33GetEpicWeaponOverwhelmingCriticalEP8CNWSItem, HookOrder.Late);
+      getEpicWeaponDevastatingCriticalHook = hookService.RequestHook<GetEpicWeaponDevastatingCriticalHook>(OnGetEpicWeaponDevastatingCritical, FunctionsLinux._ZN17CNWSCreatureStats32GetEpicWeaponDevastatingCriticalEP8CNWSItem, HookOrder.Late);
+      getWeaponSpecializationHook = hookService.RequestHook<GetWeaponSpecializationHook>(OnGetWeaponSpecialization, FunctionsLinux._ZN17CNWSCreatureStats23GetWeaponSpecializationEP8CNWSItem, HookOrder.Late);
+      getEpicWeaponSpecializationHook = hookService.RequestHook<GetEpicWeaponSpecializationHook>(OnGetEpicWeaponSpecialization, FunctionsLinux._ZN17CNWSCreatureStats27GetEpicWeaponSpecializationEP8CNWSItem, HookOrder.Late);
+      getIsWeaponOfChoiceHook = hookService.RequestHook<GetIsWeaponOfChoiceHook>(OnGetIsWeaponOfChoice, FunctionsLinux._ZN17CNWSCreatureStats19GetIsWeaponOfChoiceEj, HookOrder.Late);
+      getDamageBonusHook = hookService.RequestHook<GetDamageBonusHook>(OnGetDamageBonus, FunctionsLinux._ZN17CNWSCreatureStats14GetDamageBonusEP12CNWSCreaturei, HookOrder.Late);
+      getMeleeDamageBonusHook = hookService.RequestHook<GetMeleeDamageBonusHook>(OnGetMeleeDamageBonus, FunctionsLinux._ZN17CNWSCreatureStats19GetMeleeDamageBonusEih, HookOrder.Late);
+      getRangedDamageBonusHook = hookService.RequestHook<GetRangedDamageBonusHook>(OnGetRangedDamageBonus, FunctionsLinux._ZN17CNWSCreatureStats20GetRangedDamageBonusEv, HookOrder.Late);
+      getMeleeAttackBonusHook = hookService.RequestHook<GetMeleeAttackBonusHook>(OnGetMeleeAttackBonus, FunctionsLinux._ZN17CNWSCreatureStats19GetMeleeAttackBonusEiii, HookOrder.Late);
+      getRangedAttackBonusHook = hookService.RequestHook<GetRangedAttackBonusHook>(OnGetRangedAttackBonus, FunctionsLinux._ZN17CNWSCreatureStats20GetRangedAttackBonusEii, HookOrder.Late);
+      getAttackModifierVersusHook = hookService.RequestHook<GetAttackModifierVersusHook>(OnGetAttackModifierVersus, FunctionsLinux._ZN17CNWSCreatureStats23GetAttackModifierVersusEP12CNWSCreature, HookOrder.Late);
+      getUseMonkAttackTablesHook = hookService.RequestHook<GetUseMonkAttackTablesHook>(OnGetUseMonkAttackTables, FunctionsLinux._ZN17CNWSCreatureStats22GetUseMonkAttackTablesEi, HookOrder.Final);
+
+      weaponFinesseSizeMap[(uint)BaseItem.Rapier] = (byte)CreatureSize.Medium;
+    }
+
+    private int OnGetWeaponFocus(void* pStats, void* pWeapon)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetEpicWeaponFocus(void* pStats, void* pWeapon)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetWeaponFinesse(void* pStats, void* pWeapon)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetWeaponImprovedCritical(void* pStats, void* pWeapon)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetEpicWeaponOverwhelmingCritical(void* pStats, void* pWeapon)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetEpicWeaponDevastatingCritical(void* pStats, void* pWeapon)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetWeaponSpecialization(void* pStats, void* pWeapon)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetEpicWeaponSpecialization(void* pStats, void* pWeapon)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetIsWeaponOfChoice(void* pStats, uint nBaseItem)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetDamageBonus(void* pStats, void* pCreature, int bOffHand)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetMeleeDamageBonus(void* pStats, int bOffHand, byte nCreatureWeaponIndex)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetRangedDamageBonus(void* pStats)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetMeleeAttackBonus(void* pStats, int bOffHand, int bIncludeBase, int bTouchAttack)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetRangedAttackBonus(void* pStats, int bIncludeBase, int bTouchAttack)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetAttackModifierVersus(void* pStats, void* pCreature)
+    {
+      throw new NotImplementedException();
+    }
+
+    private int OnGetUseMonkAttackTables(void* pStats, int bForceUnarmed)
+    {
+      throw new NotImplementedException();
+    }
+  }
+}

--- a/src/main/NWN/Services/Weapon/WeaponService.cs
+++ b/src/main/NWN/Services/Weapon/WeaponService.cs
@@ -21,20 +21,35 @@ namespace NWN.Services
     private readonly EventService eventService;
 
     private delegate int GetWeaponFocusHook(void* pStats, void* pWeapon);
+
     private delegate int GetEpicWeaponFocusHook(void* pStats, void* pWeapon);
+
     private delegate int GetWeaponFinesseHook(void* pStats, void* pWeapon);
+
     private delegate int GetWeaponImprovedCriticalHook(void* pStats, void* pWeapon);
+
     private delegate int GetEpicWeaponOverwhelmingCriticalHook(void* pStats, void* pWeapon);
+
     private delegate int GetEpicWeaponDevastatingCriticalHook(void* pStats, void* pWeapon);
+
     private delegate int GetWeaponSpecializationHook(void* pStats, void* pWeapon);
+
     private delegate int GetEpicWeaponSpecializationHook(void* pStats, void* pWeapon);
+
     private delegate int GetIsWeaponOfChoiceHook(void* pStats, uint nBaseItem);
+
     private delegate int GetDamageBonusHook(void* pStats, void* pCreature, int bOffHand);
+
     private delegate int GetMeleeDamageBonusHook(void* pStats, int bOffHand, byte nCreatureWeaponIndex);
+
     private delegate int GetRangedDamageBonusHook(void* pStats);
+
     private delegate int GetMeleeAttackBonusHook(void* pStats, int bOffHand, int bIncludeBase, int bTouchAttack);
+
     private delegate int GetRangedAttackBonusHook(void* pStats, int bIncludeBase, int bTouchAttack);
+
     private delegate int GetAttackModifierVersusHook(void* pStats, void* pCreature);
+
     private delegate int GetUseMonkAttackTablesHook(void* pStats, int bForceUnarmed);
 
     private delegate float MaxAttackRangeHook(void* pCreature, uint oidTarget, int bBaseValue, int bPassiveRange);
@@ -56,8 +71,6 @@ namespace NWN.Services
     private readonly FunctionHook<GetAttackModifierVersusHook> getAttackModifierVersusHook;
     private readonly FunctionHook<GetUseMonkAttackTablesHook> getUseMonkAttackTablesHook;
 
-    private FunctionHook<MaxAttackRangeHook> maxAttackRangeHook;
-
     private readonly Dictionary<uint, HashSet<ushort>> weaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
     private readonly Dictionary<uint, HashSet<ushort>> epicWeaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
     private readonly Dictionary<uint, byte> weaponFinesseSizeMap = new Dictionary<uint, byte>();
@@ -75,6 +88,7 @@ namespace NWN.Services
 
     private readonly Dictionary<uint, MaxRangedAttackDistanceOverride> maxRangedAttackDistanceOverrideMap = new Dictionary<uint, MaxRangedAttackDistanceOverride>();
 
+    private FunctionHook<MaxAttackRangeHook> maxAttackRangeHook;
     private bool combatModeEventSubscribed;
 
     public WeaponService(HookService hookService, EventService eventService)

--- a/src/main/NWN/Services/Weapon/WeaponService.cs
+++ b/src/main/NWN/Services/Weapon/WeaponService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using NWN.API;
 using NWN.Native.API;
@@ -31,47 +32,48 @@ namespace NWN.Services
 
     private delegate int ToggleModeHook(void* pCreature, byte nMode);
 
-    private FunctionHook<GetWeaponFocusHook> getWeaponFocusHook;
-    private FunctionHook<GetEpicWeaponFocusHook> getEpicWeaponFocusHook;
-    private FunctionHook<GetWeaponFinesseHook> getWeaponFinesseHook;
-    private FunctionHook<GetWeaponImprovedCriticalHook> getWeaponImprovedCriticalHook;
-    private FunctionHook<GetEpicWeaponOverwhelmingCriticalHook> getEpicWeaponOverwhelmingCriticalHook;
-    private FunctionHook<GetEpicWeaponDevastatingCriticalHook> getEpicWeaponDevastatingCriticalHook;
-    private FunctionHook<GetWeaponSpecializationHook> getWeaponSpecializationHook;
-    private FunctionHook<GetEpicWeaponSpecializationHook> getEpicWeaponSpecializationHook;
-    private FunctionHook<GetIsWeaponOfChoiceHook> getIsWeaponOfChoiceHook;
-    private FunctionHook<GetDamageBonusHook> getDamageBonusHook;
-    private FunctionHook<GetMeleeDamageBonusHook> getMeleeDamageBonusHook;
-    private FunctionHook<GetRangedDamageBonusHook> getRangedDamageBonusHook;
-    private FunctionHook<GetMeleeAttackBonusHook> getMeleeAttackBonusHook;
-    private FunctionHook<GetRangedAttackBonusHook> getRangedAttackBonusHook;
-    private FunctionHook<GetAttackModifierVersusHook> getAttackModifierVersusHook;
-    private FunctionHook<GetUseMonkAttackTablesHook> getUseMonkAttackTablesHook;
-    private FunctionHook<ToggleModeHook> toggleModeHook;
+    private readonly FunctionHook<GetWeaponFocusHook> getWeaponFocusHook;
+    private readonly FunctionHook<GetEpicWeaponFocusHook> getEpicWeaponFocusHook;
+    private readonly FunctionHook<GetWeaponFinesseHook> getWeaponFinesseHook;
+    private readonly FunctionHook<GetWeaponImprovedCriticalHook> getWeaponImprovedCriticalHook;
+    private readonly FunctionHook<GetEpicWeaponOverwhelmingCriticalHook> getEpicWeaponOverwhelmingCriticalHook;
+    private readonly FunctionHook<GetEpicWeaponDevastatingCriticalHook> getEpicWeaponDevastatingCriticalHook;
+    private readonly FunctionHook<GetWeaponSpecializationHook> getWeaponSpecializationHook;
+    private readonly FunctionHook<GetEpicWeaponSpecializationHook> getEpicWeaponSpecializationHook;
+    private readonly FunctionHook<GetIsWeaponOfChoiceHook> getIsWeaponOfChoiceHook;
+    private readonly FunctionHook<GetDamageBonusHook> getDamageBonusHook;
+    private readonly FunctionHook<GetMeleeDamageBonusHook> getMeleeDamageBonusHook;
+    private readonly FunctionHook<GetRangedDamageBonusHook> getRangedDamageBonusHook;
+    private readonly FunctionHook<GetMeleeAttackBonusHook> getMeleeAttackBonusHook;
+    private readonly FunctionHook<GetRangedAttackBonusHook> getRangedAttackBonusHook;
+    private readonly FunctionHook<GetAttackModifierVersusHook> getAttackModifierVersusHook;
+    private readonly FunctionHook<GetUseMonkAttackTablesHook> getUseMonkAttackTablesHook;
+    private readonly FunctionHook<ToggleModeHook> toggleModeHook;
 
-    private Dictionary<uint, HashSet<ushort>> weaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
-    private Dictionary<uint, HashSet<ushort>> epicWeaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
-    private Dictionary<uint, byte> weaponFinesseSizeMap = new Dictionary<uint, byte>();
-    private Dictionary<uint, HashSet<ushort>> weaponImprovedCriticalMap = new Dictionary<uint, HashSet<ushort>>();
-    private Dictionary<uint, HashSet<ushort>> weaponSpecializationMap = new Dictionary<uint, HashSet<ushort>>();
-    private Dictionary<uint, HashSet<ushort>> epicWeaponSpecializationMap = new Dictionary<uint, HashSet<ushort>>();
-    private Dictionary<uint, HashSet<ushort>> epicWeaponOverwhelmingCriticalMap = new Dictionary<uint, HashSet<ushort>>();
-    private Dictionary<uint, HashSet<ushort>> epicWeaponDevastatingCriticalMap = new Dictionary<uint, HashSet<ushort>>();
-    private Dictionary<uint, HashSet<ushort>> weaponOfChoiceMap = new Dictionary<uint, HashSet<ushort>>();
-    private Dictionary<uint, HashSet<ushort>> greaterWeaponSpecializationMap = new Dictionary<uint, HashSet<ushort>>();
-    private Dictionary<uint, HashSet<ushort>> greaterWeaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
+    private readonly Dictionary<uint, HashSet<ushort>> weaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
+    private readonly Dictionary<uint, HashSet<ushort>> epicWeaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
+    private readonly Dictionary<uint, byte> weaponFinesseSizeMap = new Dictionary<uint, byte>();
+    private readonly Dictionary<uint, HashSet<ushort>> weaponImprovedCriticalMap = new Dictionary<uint, HashSet<ushort>>();
+    private readonly Dictionary<uint, HashSet<ushort>> weaponSpecializationMap = new Dictionary<uint, HashSet<ushort>>();
+    private readonly Dictionary<uint, HashSet<ushort>> epicWeaponSpecializationMap = new Dictionary<uint, HashSet<ushort>>();
+    private readonly Dictionary<uint, HashSet<ushort>> epicWeaponOverwhelmingCriticalMap = new Dictionary<uint, HashSet<ushort>>();
+    private readonly Dictionary<uint, HashSet<ushort>> epicWeaponDevastatingCriticalMap = new Dictionary<uint, HashSet<ushort>>();
+    private readonly Dictionary<uint, HashSet<ushort>> weaponOfChoiceMap = new Dictionary<uint, HashSet<ushort>>();
+    private readonly Dictionary<uint, HashSet<ushort>> greaterWeaponSpecializationMap = new Dictionary<uint, HashSet<ushort>>();
+    private readonly Dictionary<uint, HashSet<ushort>> greaterWeaponFocusMap = new Dictionary<uint, HashSet<ushort>>();
 
-    private HashSet<uint> weaponUnarmedSet = new HashSet<uint>();
-    private HashSet<uint> monkWeaponSet = new HashSet<uint>();
-
-    private DevastatingCriticalData dcData;
-    private Action<DevastatingCriticalData> dcCallback;
-
-    private int greaterFocusAttackBonus = 1;
-    private int greaterWeaponSpecializationDamageBonus = 2;
-    private bool gaSling = false;
+    private readonly HashSet<uint> weaponUnarmedSet = new HashSet<uint>();
+    private readonly HashSet<uint> monkWeaponSet = new HashSet<uint>();
 
     private Dictionary<uint, MaxRangedAttackDistanceOverride> maxRangedAttackDistanceOverrideMap = new Dictionary<uint, MaxRangedAttackDistanceOverride>();
+
+    public int EpicWeaponFocusAttackBonus { get; set; } = 1;
+
+    public int EpicWeaponSpecializationDamageBonus { get; set; } = 2;
+
+    public bool EnableSlingGoodAimFeat { get; set; } = false;
+
+    public event Action<DevastatingCriticalData> OnDevastatingCriticalHit;
 
     public WeaponService(HookService hookService)
     {
@@ -228,7 +230,7 @@ namespace NWN.Services
 
       bool canUseFeat = applicableFeatExists && hasApplicableFeat || getEpicWeaponDevastatingCriticalHook.CallOriginal(pStats, pWeapon).ToBool();
 
-      if (canUseFeat && dcCallback != null)
+      if (canUseFeat && OnDevastatingCriticalHit != null)
       {
         CNWSCreature creature = stats.m_pBaseCreature;
         CNWSCombatRound combatRound = creature.m_pcCombatRound;
@@ -241,7 +243,7 @@ namespace NWN.Services
           Damage = attackData.GetTotalDamage(1),
         };
 
-        dcCallback(devastatingCriticalData);
+        OnDevastatingCriticalHit(devastatingCriticalData);
         if (devastatingCriticalData.Bypass)
         {
           attackData.m_bKillingBlow = 0;
@@ -347,7 +349,7 @@ namespace NWN.Services
 
       if (applicableFeatExists && hasApplicableFeat)
       {
-        damageBonus += greaterWeaponSpecializationDamageBonus;
+        damageBonus += EpicWeaponSpecializationDamageBonus;
         if ((*NWNXLib.EnableCombatDebugging()).ToBool() && stats.m_bIsPC.ToBool())
         {
           CNWSCombatAttackData currentAttack = creature.m_pcCombatRound.GetAttack(creature.m_pcCombatRound.m_nCurrentAttack);
@@ -357,14 +359,14 @@ namespace NWN.Services
           if (currentAttack.m_nAttackResult == 3)
           {
             int criticalThreat = stats.GetCriticalHitMultiplier(bOffHand);
-            debugMessage.Append(greaterWeaponSpecializationDamageBonus * criticalThreat);
+            debugMessage.Append(EpicWeaponSpecializationDamageBonus * criticalThreat);
             debugMessage.Append(" (Greater Weapon Specialization Feat) (Critical x");
             debugMessage.Append(criticalThreat);
             debugMessage.Append(")");
           }
           else
           {
-            debugMessage.Append(greaterWeaponSpecializationDamageBonus);
+            debugMessage.Append(EpicWeaponSpecializationDamageBonus);
             debugMessage.Append(" (Greater Weapon Specialization Feat) ");
           }
 
@@ -408,7 +410,7 @@ namespace NWN.Services
 
       if (applicableFeatExists && hasApplicableFeat)
       {
-        return damageBonus + greaterWeaponSpecializationDamageBonus;
+        return damageBonus + EpicWeaponSpecializationDamageBonus;
       }
 
       return damageBonus;
@@ -444,7 +446,7 @@ namespace NWN.Services
 
       if (applicableFeatExists && hasApplicableFeat)
       {
-        return damageBonus + greaterWeaponSpecializationDamageBonus;
+        return damageBonus + EpicWeaponSpecializationDamageBonus;
       }
 
       return damageBonus;
@@ -483,7 +485,7 @@ namespace NWN.Services
 
       if (applicableFeatExists && hasApplicableFeat)
       {
-        return attackBonus + greaterFocusAttackBonus;
+        return attackBonus + EpicWeaponFocusAttackBonus;
       }
 
       return attackBonus;
@@ -524,10 +526,10 @@ namespace NWN.Services
 
       if (applicableFeatExists && hasApplicableFeat)
       {
-        attackBonus += greaterFocusAttackBonus;
+        attackBonus += EpicWeaponFocusAttackBonus;
       }
 
-      if (gaSling && baseItem == (uint)BaseItem.Sling && stats.m_nRace != (ushort)RacialType.Halfling && stats.HasFeat((ushort)Feat.GoodAim).ToBool())
+      if (EnableSlingGoodAimFeat && baseItem == (uint)BaseItem.Sling && stats.m_nRace != (ushort)RacialType.Halfling && stats.HasFeat((ushort)Feat.GoodAim).ToBool())
       {
         attackBonus += 1;
       }
@@ -537,12 +539,112 @@ namespace NWN.Services
 
     private int OnGetAttackModifierVersus(void* pStats, void* pCreature)
     {
-      throw new NotImplementedException();
+      int attackMod = getAttackModifierVersusHook.CallOriginal(pStats, pCreature);
+
+      CNWSCreatureStats stats = CNWSCreatureStats.FromPointer(pStats);
+      CNWSCreature creature = stats.m_pBaseCreature;
+      CNWSCombatRound combatRound = creature.m_pcCombatRound;
+
+      if (combatRound == null)
+      {
+        return attackMod;
+      }
+
+      CNWSItem weapon = combatRound.GetCurrentAttackWeapon(combatRound.GetWeaponAttackType());
+      if (weapon == null)
+      {
+        return attackMod;
+      }
+
+      uint baseItem = weapon.m_nBaseItem;
+      bool hasApplicableFeat = false;
+      bool applicableFeatExists = greaterWeaponFocusMap.TryGetValue(baseItem, out HashSet<ushort> types);
+
+      if (applicableFeatExists)
+      {
+        foreach (ushort feat in types)
+        {
+          hasApplicableFeat = stats.HasFeat(feat).ToBool();
+          if (hasApplicableFeat)
+          {
+            break;
+          }
+        }
+      }
+
+      if (applicableFeatExists && hasApplicableFeat)
+      {
+        attackMod += EpicWeaponFocusAttackBonus;
+
+        if ((*NWNXLib.EnableCombatDebugging()).ToBool() && stats.m_bIsPC.ToBool())
+        {
+          CNWSCombatAttackData currentAttack = combatRound.GetAttack(combatRound.m_nCurrentAttack);
+          StringBuilder debugMessage = new StringBuilder(currentAttack.m_sDamageDebugText.ToString());
+          debugMessage.Append(" + ");
+          debugMessage.Append(EpicWeaponFocusAttackBonus);
+          debugMessage.Append(" (Greater Weapon Focus Feat)");
+
+          currentAttack.m_sDamageDebugText = debugMessage.ToString().ToExoString();
+        }
+      }
+
+      if (EnableSlingGoodAimFeat && baseItem == (uint)BaseItem.Sling && stats.m_nRace != (ushort)RacialType.Halfling && stats.HasFeat((ushort)Feat.GoodAim).ToBool())
+      {
+        int goodAimModifier = NWNXLib.Rules().GetRulesetIntEntry("GOOD_AIM_MODIFIER".ToExoString(), 1);
+        attackMod += goodAimModifier;
+
+        if ((*NWNXLib.EnableCombatDebugging()).ToBool() && stats.m_bIsPC.ToBool())
+        {
+          CNWSCombatAttackData currentAttack = combatRound.GetAttack(combatRound.m_nCurrentAttack);
+          StringBuilder debugMessage = new StringBuilder(currentAttack.m_sDamageDebugText.ToString());
+          debugMessage.Append(" + ");
+          debugMessage.Append(goodAimModifier);
+          debugMessage.Append(" (Good Aim Feat)");
+
+          currentAttack.m_sDamageDebugText = debugMessage.ToString().ToExoString();
+        }
+      }
+
+      return attackMod;
     }
 
     private int OnGetUseMonkAttackTables(void* pStats, int bForceUnarmed)
     {
-      throw new NotImplementedException();
+      CNWSCreatureStats stats = CNWSCreatureStats.FromPointer(pStats);
+      CNWSCreature creature = stats.m_pBaseCreature;
+
+      int monkLevels = GetLevelByClass(stats, (uint)ClassType.Monk);
+
+      if (monkLevels < 1 || !creature.GetUseMonkAbilities().ToBool())
+      {
+        return false.ToInt();
+      }
+
+      CNWSItem mainWeapon = creature.m_pInventory.GetItemInSlot((uint)EquipmentSlot.RightHand);
+      if (mainWeapon == null)
+      {
+        return true.ToInt();
+      }
+
+      if (bForceUnarmed.ToBool())
+      {
+        return false.ToInt();
+      }
+
+      uint mainWeaponType = mainWeapon.m_nBaseItem;
+      if (mainWeaponType != (uint)BaseItem.Kama && !monkWeaponSet.Contains(mainWeapon.m_nBaseItem))
+      {
+        return false.ToInt();
+      }
+
+      CNWSItem secondWeapon = creature.m_pInventory.GetItemInSlot((uint)EquipmentSlot.LeftHand);
+      if (secondWeapon == null)
+      {
+        return true.ToInt();
+      }
+
+      uint secondWeaponType = secondWeapon.m_nBaseItem;
+      return (secondWeaponType == (uint)BaseItem.Kama || secondWeaponType == (uint)BaseItem.Torch || monkWeaponSet.Contains(secondWeaponType)).ToInt();
     }
 
     private bool IsWeaponLight(CNWSCreatureStats stats, CNWSItem weapon, bool finesse)
@@ -633,6 +735,20 @@ namespace NWN.Services
       }
 
       return weapon;
+    }
+
+    private int GetLevelByClass(CNWSCreatureStats stats, uint classType)
+    {
+      for (int i = 0; i < stats.m_nNumMultiClasses; i++)
+      {
+        CNWSCreatureStats_ClassInfo classInfo = stats.m_ClassInfo[i];
+        if (classInfo.m_nClass == classType)
+        {
+          return classInfo.m_nLevel;
+        }
+      }
+
+      return 0;
     }
   }
 }


### PR DESCRIPTION
Adds the following properties and methods:

```cs
    /// <summary>
    /// Gets or sets the attack bonus granted to a creature with a "Greater Weapon Focus" feat.<br/>
    /// This does not exist in the base game, see <see cref="AddGreaterWeaponFocusFeat"/> to add feats that grant this bonus.
    /// </summary>
    public int GreaterWeaponFocusAttackBonus { get; set; } = 1;

    /// <summary>
    /// Gets or sets the damage bonus granted to a creature with a "Greater Weapon Specialization" feat.<br/>
    /// This does not exist in the base game, see <see cref="AddGreaterWeaponSpecializationFeat"/> to add feats that grant this bonus.
    /// </summary>
    public int GreaterWeaponSpecializationDamageBonus { get; set; } = 2;

    /// <summary>
    /// Gets or sets whether the "Good Aim" feat should also apply to slings.
    /// </summary>
    public bool EnableSlingGoodAimFeat { get; set; } = false;

    /// <summary>
    /// Called when an attack results in a devastating critical hit. Subscribe and modify the event data to implement custom behaviours.
    /// </summary>
    public event Action<DevastatingCriticalData> OnDevastatingCriticalHit;

    /// <summary>
    /// Adds the specified feat as a weapon focus feat for the specified base item type.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="feat">The feat to map to the base item.</param>
    public void AddWeaponFocusFeat(BaseItemType baseItem, NWN.API.Constants.Feat feat);

    /// <summary>
    /// Adds the specified feat as an epic weapon focus feat for the specified base item type.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="feat">The feat to map to the base item.</param>
    public void AddEpicWeaponFocusFeat(BaseItemType baseItem, NWN.API.Constants.Feat feat);

    /// <summary>
    /// Adds the specified feat as an improved critical feat for the specified base item type.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="feat">The feat to map to the base item.</param>
    public void AddWeaponImprovedCriticalFeat(BaseItemType baseItem, NWN.API.Constants.Feat feat);

    /// <summary>
    /// Adds the specified feat as a weapon specialization feat for the specified base item type.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="feat">The feat to map to the base item.</param>
    public void AddWeaponSpecializationFeat(BaseItemType baseItem, NWN.API.Constants.Feat feat);

    /// <summary>
    /// Adds the specified feat as an epic weapon specialization feat for the specified base item type.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="feat">The feat to map to the base item.</param>
    public void AddEpicWeaponSpecializationFeat(BaseItemType baseItem, NWN.API.Constants.Feat feat);

    /// <summary>
    /// Adds the specified feat as an epic overwhelming critical feat for the specified base item type.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="feat">The feat to map to the base item.</param>
    public void AddEpicWeaponOverwhelmingCriticalFeat(BaseItemType baseItem, NWN.API.Constants.Feat feat);

    /// <summary>
    /// Adds the specified feat as a devastating critical feat for the specified base item type.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="feat">The feat to map to the base item.</param>
    public void AddEpicWeaponDevastatingCriticalFeat(BaseItemType baseItem, NWN.API.Constants.Feat feat);

    /// <summary>
    /// Adds the specified feat as a weapon of choice feat for the specified base item type.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="feat">The feat to map to the base item.</param>
    public void AddWeaponOfChoiceFeat(BaseItemType baseItem, NWN.API.Constants.Feat feat);

    /// <summary>
    /// Adds the specified feat as a greater weapon focus feat for the specified base item type.<br/>
    /// This adds the <see cref="GreaterWeaponFocusAttackBonus"/> to the weapon's attack roll for characters with the specified feat.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="feat">The feat to map to the base item.</param>
    public void AddGreaterWeaponFocusFeat(BaseItemType baseItem, NWN.API.Constants.Feat feat);

    /// <summary>
    /// Adds the specified feat as a greater weapon specialization feat for the specified base item type.<br/>
    /// This adds the <see cref="GreaterWeaponSpecializationDamageBonus"/> to the weapon's damage roll for characters with the specified feat.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="feat">The feat to map to the base item.</param>
    public void AddGreaterWeaponSpecializationFeat(BaseItemType baseItem, NWN.API.Constants.Feat feat);

    /// <summary>
    /// Gets the required creature size needed for the specified base item type to be finessable. This function only returns values assigned in <see cref="SetWeaponFinesseSize"/>.
    /// </summary>
    /// <param name="baseItem">The base item type to query.</param>
    /// <returns>The size of the creature needed to consider this weapon finessable.</returns>
    public API.Constants.CreatureSize GetWeaponFinesseSize(BaseItemType baseItem);

    /// <summary>
    /// Sets the required creature size needed for the specified base item type to be finessable.
    /// </summary>
    /// <param name="baseItem">The base item type to be mapped.</param>
    /// <param name="size">The size of the creature needed to consider this weapon finessable.</param>
    public void SetWeaponFinesseSize(BaseItemType baseItem, API.Constants.CreatureSize size);

    /// <summary>
    /// Sets the specified weapon base item to be considered as unarmed for the weapon finesse feat.
    /// </summary>
    /// <param name="baseItem">The base item type to be considered unarmed.</param>
    public void SetWeaponUnarmed(BaseItemType baseItem);

    /// <summary>
    /// Sets the specified weapon base item to be considered a monk weapon.
    /// </summary>
    /// <param name="baseItem">The base item type to be considered a monk weapon.</param>
    public void SetWeaponIsMonkWeapon(BaseItemType baseItem);

    /// <summary>
    /// Overrides the max attack distance of ranged weapons.
    /// </summary>
    /// <param name="baseItem">The base item type.</param>
    /// <param name="max">The maximum attack distance. Default is 40.0f.</param>
    /// <param name="maxPassive">The maximum passive attack distance. Default is 20.0f. Seems to be used by the engine to determine a new nearby target when needed.</param>
    /// <param name="preferred">The preferred attack distance. See the PrefAttackDist column in baseitems.2da, default seems to be 30.0f for ranged weapons.</param>
    /// <remarks>maxPassive should probably be lower than max, half of max seems to be a good start. preferred should be at least ~0.5f lower than max.</remarks>
    public void SetMaxRangedAttackDistanceOverride(BaseItemType baseItem, float max, float maxPassive, float preferred);
```