### PR TITLE
Fix upcast of Caster in spell events

### DIFF
--- a/src/main/NWN/API/Events/Native/SpellEvents/OnSpellBroadcast.cs
+++ b/src/main/NWN/API/Events/Native/SpellEvents/OnSpellBroadcast.cs
@@ -10,7 +10,7 @@ namespace NWN.API.Events
   {
     public bool PreventSpellCast { get; set; }
 
-    public NwGameObject Caster { get; private init; }
+    public NwCreature Caster { get; private init; }
 
     public Spell Spell { get; private init; }
 

--- a/src/main/NWN/API/Events/Native/SpellEvents/OnSpellCast.cs
+++ b/src/main/NWN/API/Events/Native/SpellEvents/OnSpellCast.cs
@@ -54,7 +54,7 @@ namespace NWN.API.Events
 
         OnSpellCast eventData = ProcessEvent(new OnSpellCast
         {
-          Caster = gameObject.ToNwObject<NwCreature>(),
+          Caster = gameObject.ToNwObject<NwGameObject>(),
           Spell = (Spell)nSpellId,
           TargetPosition = targetPosition,
           TargetObject = oidTarget.ToNwObject<NwGameObject>(),


### PR DESCRIPTION
Considering the object initialization of `Caster = gameObject.ToNwObject<NwCreature>()` I figured these props have the wrong type.