### PR TITLE
Implement property based dependency injection

### DIFF
--- a/src/main/Anvil/AnvilCore.cs
+++ b/src/main/Anvil/AnvilCore.cs
@@ -13,7 +13,7 @@ namespace Anvil
 {
   /// <summary>
   /// Handles bootstrap and interop between %NWN, %NWN.Core and the %Anvil %API. The entry point of the implementing module should point to this class.<br/>
-  /// Until <see cref="Init(IntPtr, int, IContainerBuilder, ITypeLoader)"/> is called, all APIs are unavailable for usage.
+  /// Until <see cref="Init(IntPtr, int, IContainerFactory, ITypeLoader)"/> is called, all APIs are unavailable for usage.
   /// </summary>
   public sealed class AnvilCore : ICoreSignalHandler
   {
@@ -23,7 +23,7 @@ namespace Anvil
 
     // Core Services
     private CoreInteropHandler interopHandler;
-    private IContainerBuilder containerBuilder;
+    private IContainerFactory containerFactory;
     private ITypeLoader typeLoader;
     private LoggerManager loggerManager;
     private ServiceManager serviceManager;
@@ -33,18 +33,18 @@ namespace Anvil
     /// </summary>
     /// <param name="arg">The NativeHandles pointer, provided by the NWNX bootstrap entry point.</param>
     /// <param name="argLength">The size of the NativeHandles bootstrap structure, provided by the NWNX entry point.</param>
-    /// <param name="containerBuilder">An optional custom binding installer to use instead of the default <see cref="ServiceBindingContainerBuilder"/>.</param>
+    /// <param name="containerFactory">An optional custom binding installer to use instead of the default <see cref="AnvilContainerFactory"/>.</param>
     /// <param name="typeLoader">An optional type loader to use instead of the default <see cref="PluginLoader"/>.</param>
     /// <returns>The init result code to return back to NWNX.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int Init(IntPtr arg, int argLength, IContainerBuilder containerBuilder = default, ITypeLoader typeLoader = default)
+    public static int Init(IntPtr arg, int argLength, IContainerFactory containerFactory = default, ITypeLoader typeLoader = default)
     {
       typeLoader ??= new PluginLoader();
-      containerBuilder ??= new ServiceBindingContainerBuilder();
+      containerFactory ??= new AnvilContainerFactory();
 
       instance = new AnvilCore();
       instance.interopHandler = new CoreInteropHandler(instance);
-      instance.containerBuilder = containerBuilder;
+      instance.containerFactory = containerFactory;
       instance.typeLoader = typeLoader;
       instance.loggerManager = new LoggerManager();
 
@@ -108,7 +108,7 @@ namespace Anvil
 
     private void Start()
     {
-      serviceManager = new ServiceManager(typeLoader, containerBuilder);
+      serviceManager = new ServiceManager(typeLoader, containerFactory);
 
       serviceManager.RegisterCoreService(typeLoader);
       serviceManager.RegisterCoreService(serviceManager);

--- a/src/main/NWN/API/Events/Game/GameEventFactory.cs
+++ b/src/main/NWN/API/Events/Game/GameEventFactory.cs
@@ -14,17 +14,14 @@ namespace NWN.API.Events
   {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
-    private readonly Lazy<EventService> eventService;
+    // Dependencies
+    [Inject]
+    private Lazy<EventService> EventService { get; init; }
 
     // Caches
     private readonly Dictionary<Type, GameEventAttribute> eventInfoCache = new Dictionary<Type, GameEventAttribute>();
     private readonly Dictionary<EventScriptType, Func<IEvent>> eventConstructorCache = new Dictionary<EventScriptType, Func<IEvent>>();
     private readonly Dictionary<EventKey, string> originalCallLookup = new Dictionary<EventKey, string>();
-
-    public GameEventFactory(Lazy<EventService> eventService)
-    {
-      this.eventService = eventService;
-    }
 
     public void Register<TEvent>(RegistrationData data) where TEvent : IEvent, new()
     {
@@ -38,7 +35,7 @@ namespace NWN.API.Events
 
     ScriptHandleResult IScriptDispatcher.ExecuteScript(string scriptName, uint oidSelf)
     {
-      if (eventService == null || scriptName != ScriptConstants.GameEventScriptName)
+      if (EventService == null || scriptName != ScriptConstants.GameEventScriptName)
       {
         return ScriptHandleResult.NotHandled;
       }
@@ -56,7 +53,7 @@ namespace NWN.API.Events
           NWScript.ExecuteScript(scriptName, oidSelf);
         }
 
-        eventService.Value.ProcessEvent(value.Invoke());
+        EventService.Value.ProcessEvent(value.Invoke());
         return ScriptHandleResult.Handled;
       }
 

--- a/src/main/NWN/API/Events/Native/HookEventFactory.cs
+++ b/src/main/NWN/API/Events/Native/HookEventFactory.cs
@@ -5,23 +5,14 @@ namespace NWN.API.Events
 {
   public abstract class HookEventFactory
   {
+    [Inject]
     protected static Lazy<EventService> EventService { get; private set; }
 
+    [Inject]
     protected static HookService HookService { get; private set; }
 
+    [Inject]
     protected static VirtualMachine VirtualMachine { get; private set; }
-
-    [ServiceBinding(typeof(APIBindings))]
-    [ServiceBindingOptions(BindingOrder.API)]
-    internal sealed class APIBindings
-    {
-      public APIBindings(Lazy<EventService> eventService, HookService hookService, VirtualMachine virtualMachine)
-      {
-        EventService = eventService;
-        HookService = hookService;
-        VirtualMachine = virtualMachine;
-      }
-    }
 
     protected static TEvent ProcessEvent<TEvent>(TEvent eventData, bool executeInScriptContext = true) where TEvent : IEvent
     {

--- a/src/main/NWN/API/Object/NwCreature.cs
+++ b/src/main/NWN/API/Object/NwCreature.cs
@@ -857,20 +857,6 @@ namespace NWN.API
     }
 
     /// <summary>
-    /// Gets all effects (permanent and temporary) that are active on this creature.
-    /// </summary>
-    public IEnumerable<Effect> ActiveEffects
-    {
-      get
-      {
-        for (Effect effect = NWScript.GetFirstEffect(this); NWScript.GetIsEffectValid(effect) == true.ToInt(); effect = NWScript.GetNextEffect(this))
-        {
-          yield return effect;
-        }
-      }
-    }
-
-    /// <summary>
     /// Gets or sets this creature's Chaos (0) - Lawful (100) alignment value.
     /// </summary>
     public int LawChaosValue

--- a/src/main/NWN/API/Object/NwGameObject.cs
+++ b/src/main/NWN/API/Object/NwGameObject.cs
@@ -152,6 +152,20 @@ namespace NWN.API
       set => NWScript.SetObjectMouseCursor(this, (int)value);
     }
 
+    /// <summary>
+    /// Gets all effects (permanent and temporary) that are active on this game object.
+    /// </summary>
+    public IEnumerable<Effect> ActiveEffects
+    {
+      get
+      {
+        for (Effect effect = NWScript.GetFirstEffect(this); NWScript.GetIsEffectValid(effect) == true.ToInt(); effect = NWScript.GetNextEffect(this))
+        {
+          yield return effect;
+        }
+      }
+    }
+
     public override Guid? PeekUUID()
     {
       CNWSUUID uid = GameObject.m_pUUID;

--- a/src/main/NWN/API/Object/NwObject.cs
+++ b/src/main/NWN/API/Object/NwObject.cs
@@ -13,23 +13,14 @@ namespace NWN.API
   [DebuggerDisplay("{" + nameof(Name) + "}")]
   public abstract partial class NwObject : IEquatable<NwObject>
   {
+    [Inject]
     private protected static EventService EventService { get; private set; }
 
+    [Inject]
     private protected static ResourceManager ResourceManager { get; private set; }
 
+    [Inject]
     private protected static VirtualMachine VirtualMachine { get; private set; }
-
-    [ServiceBinding(typeof(APIBindings))]
-    [ServiceBindingOptions(BindingOrder.API)]
-    internal sealed class APIBindings
-    {
-      public APIBindings(EventService eventService, ResourceManager resourceManager, VirtualMachine virtualMachine)
-      {
-        EventService = eventService;
-        ResourceManager = resourceManager;
-        VirtualMachine = virtualMachine;
-      }
-    }
 
     internal const uint Invalid = NWScript.OBJECT_INVALID;
 

--- a/src/main/NWN/API/Object/NwPlayer.cs
+++ b/src/main/NWN/API/Object/NwPlayer.cs
@@ -19,17 +19,8 @@ namespace NWN.API
   {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
+    [Inject]
     private static EventService EventService { get; set; }
-
-    [ServiceBinding(typeof(APIBindings))]
-    [ServiceBindingOptions(BindingOrder.API)]
-    internal sealed class APIBindings
-    {
-      public APIBindings(EventService eventService)
-      {
-        EventService = eventService;
-      }
-    }
 
     internal readonly CNWSPlayer Player;
     internal readonly uint PlayerId;

--- a/src/main/NWN/API/Variable/Campaign/CampaignVariable.cs
+++ b/src/main/NWN/API/Variable/Campaign/CampaignVariable.cs
@@ -5,17 +5,8 @@ namespace NWN.API
 {
   public abstract class CampaignVariable
   {
+    [Inject]
     private protected static VariableConverterService VariableConverterService { get; private set; }
-
-    [ServiceBinding(typeof(APIBindings))]
-    [ServiceBindingOptions(BindingOrder.API)]
-    internal sealed class APIBindings
-    {
-      public APIBindings(VariableConverterService variableConverterService)
-      {
-        VariableConverterService = variableConverterService;
-      }
-    }
 
     public string Campaign { get; protected set; }
 

--- a/src/main/NWN/API/Variable/Local/LocalVariable.cs
+++ b/src/main/NWN/API/Variable/Local/LocalVariable.cs
@@ -6,17 +6,8 @@ namespace NWN.API
 {
   public abstract class LocalVariable
   {
+    [Inject]
     private protected static VariableConverterService VariableConverterService { get; private set; }
-
-    [ServiceBinding(typeof(APIBindings))]
-    [ServiceBindingOptions(BindingOrder.API)]
-    internal sealed class APIBindings
-    {
-      public APIBindings(VariableConverterService variableConverterService)
-      {
-        VariableConverterService = variableConverterService;
-      }
-    }
 
     public string Name { get; protected set; }
 

--- a/src/main/NWN/Services/Chat/ChatService.EventFactory.cs
+++ b/src/main/NWN/Services/Chat/ChatService.EventFactory.cs
@@ -7,8 +7,12 @@ namespace NWN.Services
   [ServiceBinding(typeof(IEventFactory))]
   public sealed partial class ChatService : IEventFactory<NullRegistrationData>
   {
-    private readonly VirtualMachine virtualMachine;
-    private readonly Lazy<EventService> eventService;
+    // Dependencies
+    [Inject]
+    private Lazy<EventService> EventService { get; init; }
+
+    [Inject]
+    private VirtualMachine VirtualMachine { get; init; }
 
     private bool isEventHooked;
 
@@ -16,9 +20,9 @@ namespace NWN.Services
     {
       OnChatMessageSend eventData = null;
 
-      virtualMachine.ExecuteInScriptContext(() =>
+      VirtualMachine.ExecuteInScriptContext(() =>
       {
-        eventData = eventService.Value.ProcessEvent(new OnChatMessageSend
+        eventData = EventService.Value.ProcessEvent(new OnChatMessageSend
         {
           ChatChannel = chatChannel,
           Message = message,

--- a/src/main/NWN/Services/Chat/ChatService.cs
+++ b/src/main/NWN/Services/Chat/ChatService.cs
@@ -26,10 +26,8 @@ namespace NWN.Services
 
     private bool customHearingDistances;
 
-    public ChatService(Lazy<EventService> eventService, HookService hookService, VirtualMachine virtualMachine)
+    public ChatService(HookService hookService)
     {
-      this.virtualMachine = virtualMachine;
-      this.eventService = eventService;
       sendServerToPlayerChatMessageHook = hookService.RequestHook<SendServerToPlayerChatMessageHook>(OnSendServerToPlayerChatMessage, FunctionsLinux._ZN11CNWSMessage29SendServerToPlayerChatMessageEhj10CExoStringjRKS0_, HookOrder.Late);
     }
 

--- a/src/main/NWN/Services/Chat/ChatService.cs
+++ b/src/main/NWN/Services/Chat/ChatService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Anvil.Internal;
 using NWN.API;

--- a/src/main/NWN/Services/ScriptDispatch/AttributeDispatchService.cs
+++ b/src/main/NWN/Services/ScriptDispatch/AttributeDispatchService.cs
@@ -11,20 +11,18 @@ namespace NWN.Services
   [ServiceBinding(typeof(IInitializable))]
   internal sealed class AttributeDispatchService : IScriptDispatcher, IInitializable
   {
-    private const int StartCapacity = 2000;
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+    private const int StartCapacity = 2000;
+
+    // All Services
+    [Inject]
+    private Lazy<IEnumerable<object>> Services { get; init; }
 
     private readonly Dictionary<string, ScriptCallback> scriptHandlers = new Dictionary<string, ScriptCallback>(StartCapacity);
-    private readonly ServiceManager serviceManager;
-
-    public AttributeDispatchService(ServiceManager serviceManager)
-    {
-      this.serviceManager = serviceManager;
-    }
 
     void IInitializable.Init()
     {
-      foreach (object service in serviceManager.RegisteredServices)
+      foreach (object service in Services.Value)
       {
         RegisterServiceListeners(service);
       }

--- a/src/main/NWN/Services/Services/AnvilContainerFactory.cs
+++ b/src/main/NWN/Services/Services/AnvilContainerFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Reflection;
 using LightInject;
 using NLog;
@@ -45,7 +44,7 @@ namespace NWN.Services
 
     private void SetupInjectPropertySelector()
     {
-      InjectPropertySelector propertySelector = new InjectPropertySelector();
+      InjectPropertySelector propertySelector = new InjectPropertySelector(InjectPropertyTypes.InstanceOnly);
       ServiceContainer.PropertyDependencySelector = new InjectPropertyDependencySelector(propertySelector);
     }
 

--- a/src/main/NWN/Services/Services/IContainerFactory.cs
+++ b/src/main/NWN/Services/Services/IContainerFactory.cs
@@ -3,7 +3,7 @@ using NWN.Plugins;
 
 namespace NWN.Services
 {
-  public interface IContainerBuilder
+  public interface IContainerFactory
   {
     ServiceContainer Setup(ITypeLoader typeLoader);
 

--- a/src/main/NWN/Services/Services/InjectAttribute.cs
+++ b/src/main/NWN/Services/Services/InjectAttribute.cs
@@ -1,0 +1,32 @@
+using System;
+using JetBrains.Annotations;
+
+namespace NWN.Services
+{
+  /// <summary>
+  /// Indicates a property as a service dependency to be injected.
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Property)]
+  [MeansImplicitUse]
+  public sealed class InjectAttribute : Attribute
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InjectAttribute"/> class.
+    /// </summary>
+    public InjectAttribute() : this(string.Empty) {}
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InjectAttribute"/> class.
+    /// </summary>
+    /// <param name="serviceName">The name of the service to be injected.</param>
+    public InjectAttribute(string serviceName)
+    {
+      ServiceName = serviceName;
+    }
+
+    /// <summary>
+    /// Gets the name of the service to be injected.
+    /// </summary>
+    public string ServiceName { get; }
+  }
+}

--- a/src/main/NWN/Services/Services/InjectPropertyDependencySelector.cs
+++ b/src/main/NWN/Services/Services/InjectPropertyDependencySelector.cs
@@ -7,8 +7,7 @@ using LightInject;
 namespace NWN.Services
 {
   /// <summary>
-  /// An <see cref="IPropertyDependencySelector"/> that uses the <see cref="InjectAttribute"/>
-  /// to determine which properties to inject dependencies.
+  /// An <see cref="IPropertyDependencySelector"/> that uses the <see cref="InjectAttribute"/> to determine which properties to inject service dependencies.
   /// </summary>
   internal sealed class InjectPropertyDependencySelector : PropertyDependencySelector
   {

--- a/src/main/NWN/Services/Services/InjectPropertyDependencySelector.cs
+++ b/src/main/NWN/Services/Services/InjectPropertyDependencySelector.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using LightInject;
+
+namespace NWN.Services
+{
+  /// <summary>
+  /// An <see cref="IPropertyDependencySelector"/> that uses the <see cref="InjectAttribute"/>
+  /// to determine which properties to inject dependencies.
+  /// </summary>
+  internal sealed class InjectPropertyDependencySelector : PropertyDependencySelector
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InjectPropertyDependencySelector"/> class.
+    /// </summary>
+    /// <param name="propertySelector">The <see cref="InjectPropertySelector"/> that is responsible for selecting a list of injectable properties.</param>
+    public InjectPropertyDependencySelector(InjectPropertySelector propertySelector) : base(propertySelector) {}
+
+    /// <summary>
+    /// Selects the property dependencies for the given <paramref name="type"/>
+    /// that is annotated with the <see cref="InjectAttribute"/>.
+    /// </summary>
+    /// <param name="type">The <see cref="Type"/> for which to select the property dependencies.</param>
+    /// <returns>A list of <see cref="PropertyDependency"/> instances that represents the property dependencies for the given <paramref name="type"/>.</returns>
+    public override IEnumerable<PropertyDependency> Execute(Type type)
+    {
+      PropertyInfo[] properties = PropertySelector.Execute(type).ToArray();
+      foreach (PropertyInfo propertyInfo in properties)
+      {
+        InjectAttribute injectAttribute = propertyInfo.GetCustomAttribute<InjectAttribute>(true);
+
+        if (injectAttribute != null)
+        {
+          yield return new PropertyDependency
+          {
+            Property = propertyInfo,
+            ServiceName = injectAttribute.ServiceName,
+            ServiceType = propertyInfo.PropertyType,
+            IsRequired = true,
+          };
+        }
+      }
+    }
+  }
+}

--- a/src/main/NWN/Services/Services/InjectPropertySelector.cs
+++ b/src/main/NWN/Services/Services/InjectPropertySelector.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using LightInject;
+using NLog;
+using NWN.API;
+
+namespace NWN.Services
+{
+  public class InjectPropertySelector : PropertySelector
+  {
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    /// <summary>
+    /// Determines if the <paramref name="propertyInfo"/> represents an injectable property.
+    /// </summary>
+    /// <param name="propertyInfo">The <see cref="PropertyInfo"/> that describes the target property.</param>
+    /// <returns><b>true</b> if the property is injectable, otherwise <b>false</b>.</returns>
+    protected override bool IsInjectable(PropertyInfo propertyInfo)
+    {
+      bool retVal = propertyInfo.SetMethod != null && propertyInfo.GetIndexParameters().Length == 0;
+      bool hasAttribute = propertyInfo.IsDefined(typeof(InjectAttribute), true);
+
+      if (!retVal && hasAttribute)
+      {
+        Log.Error($"Cannot inject property \"{propertyInfo.GetFullName()}\" as it does not have set/init defined, or is an unsupported property type.");
+      }
+
+      return retVal && hasAttribute;
+    }
+  }
+}

--- a/src/main/NWN/Services/Services/InjectPropertyTypes.cs
+++ b/src/main/NWN/Services/Services/InjectPropertyTypes.cs
@@ -1,0 +1,8 @@
+namespace NWN.Services
+{
+  public enum InjectPropertyTypes
+  {
+    InstanceOnly,
+    StaticOnly,
+  }
+}

--- a/src/main/NWN/Services/Services/InjectionService.cs
+++ b/src/main/NWN/Services/Services/InjectionService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using LightInject;
 
@@ -19,6 +20,11 @@ namespace NWN.Services
     [Pure]
     public T Inject<T>(T instance)
     {
+      if (EqualityComparer<T>.Default.Equals(instance, default))
+      {
+        return default;
+      }
+
       Container.InjectProperties(instance);
       return instance;
     }

--- a/src/main/NWN/Services/Services/InjectionService.cs
+++ b/src/main/NWN/Services/Services/InjectionService.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.Contracts;
+using LightInject;
+
+namespace NWN.Services
+{
+  [ServiceBinding(typeof(InjectionService))]
+  [ServiceBindingOptions(BindingOrder.API)]
+  public sealed class InjectionService
+  {
+    [Inject]
+    private IServiceContainer Container { get; init; }
+
+    /// <summary>
+    /// Injects all properties with <see cref="InjectAttribute"/> in the specified object.
+    /// </summary>
+    /// <param name="instance">The instance to inject.</param>
+    /// <typeparam name="T">The instance type.</typeparam>
+    /// <returns>The instance with injected dependencies.</returns>
+    [Pure]
+    public T Inject<T>(T instance)
+    {
+      Container.InjectProperties(instance);
+      return instance;
+    }
+  }
+}

--- a/src/main/NWN/Services/Services/ServiceManager.cs
+++ b/src/main/NWN/Services/Services/ServiceManager.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using LightInject;
 using NLog;
@@ -15,30 +13,27 @@ namespace NWN.Services
     [UsedImplicitly]
     private readonly ITypeLoader typeLoader;
 
-    private readonly IContainerBuilder containerBuilder;
+    private readonly IContainerFactory containerFactory;
     private readonly ServiceContainer serviceContainer;
 
-    public List<object> RegisteredServices { get; private set; }
-
-    internal ServiceManager(ITypeLoader typeLoader, IContainerBuilder containerBuilder)
+    internal ServiceManager(ITypeLoader typeLoader, IContainerFactory containerFactory)
     {
-      Log.Info($"Using \"{containerBuilder.GetType().FullName}\" to install service bindings.");
+      Log.Info($"Using \"{containerFactory.GetType().FullName}\" to install service bindings.");
 
       this.typeLoader = typeLoader;
-      this.containerBuilder = containerBuilder;
+      this.containerFactory = containerFactory;
 
-      serviceContainer = containerBuilder.Setup(typeLoader);
+      serviceContainer = containerFactory.Setup(typeLoader);
     }
 
     internal void RegisterCoreService<T>(T instance)
     {
-      containerBuilder.RegisterCoreService(instance);
+      containerFactory.RegisterCoreService(instance);
     }
 
     internal void Init()
     {
-      containerBuilder.BuildContainer();
-      RegisteredServices = serviceContainer.GetAllInstances<object>().ToList();
+      containerFactory.BuildContainer();
       NotifyInitComplete();
     }
 

--- a/src/main/NWN/Services/TwoDimArray/TwoDimArrayFactory.cs
+++ b/src/main/NWN/Services/TwoDimArray/TwoDimArrayFactory.cs
@@ -14,8 +14,15 @@ namespace NWN.Services
   [ServiceBinding(typeof(TwoDimArrayFactory))]
   public sealed class TwoDimArrayFactory
   {
+    private readonly InjectionService injectionService;
+
     private readonly CTwoDimArrays twoDimArrays = NWNXLib.Rules().m_p2DArrays;
     private readonly Dictionary<string, ITwoDimArray> cache = new Dictionary<string, ITwoDimArray>();
+
+    public TwoDimArrayFactory(InjectionService injectionService)
+    {
+      this.injectionService = injectionService;
+    }
 
     /// <summary>
     /// Deserializes the given 2da using the specified format.
@@ -38,7 +45,7 @@ namespace NWN.Services
 
     private T Load2DAToCache<T>(string name) where T : ITwoDimArray, new()
     {
-      T new2da = new T();
+      T new2da = injectionService.Inject(new T());
 
       C2DA twoDimArray = twoDimArrays.GetCached2DA(name.ToExoString(), true.ToInt());
       if (twoDimArray == null)

--- a/src/main/NWNX/Services/NWNXEventFactory.cs
+++ b/src/main/NWNX/Services/NWNXEventFactory.cs
@@ -17,16 +17,13 @@ namespace NWNX.Services
   {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
-    private readonly Lazy<EventService> eventService;
+    // Dependencies
+    [Inject]
+    private Lazy<EventService> EventService { get; init; }
 
     // Caches
     private readonly Dictionary<Type, NWNXEventAttribute> eventInfoCache = new Dictionary<Type, NWNXEventAttribute>();
     private readonly Dictionary<string, Func<IEvent>> eventConstructorCache = new Dictionary<string, Func<IEvent>>();
-
-    public NWNXEventFactory(Lazy<EventService> eventService)
-    {
-      this.eventService = eventService;
-    }
 
     public void Register<TEvent>(NullRegistrationData data) where TEvent : IEvent, new()
     {
@@ -44,7 +41,7 @@ namespace NWNX.Services
 
     ScriptHandleResult IScriptDispatcher.ExecuteScript(string scriptName, uint oidSelf)
     {
-      if (eventService == null || scriptName != ScriptConstants.NWNXEventScriptName)
+      if (scriptName != ScriptConstants.NWNXEventScriptName)
       {
         return ScriptHandleResult.NotHandled;
       }
@@ -66,7 +63,7 @@ namespace NWNX.Services
 
     private void ProcessEvent(IEvent eventInstance)
     {
-      eventService.Value.ProcessEvent(eventInstance);
+      EventService.Value.ProcessEvent(eventInstance);
 
       if (eventInstance is IEventNWNXResult nwnxEvent && nwnxEvent.EventResult != null)
       {


### PR DESCRIPTION
Services can now define their dependencies as properties

- `IInitializable` is an implicit interface that is called once all services have been injected. It does not work on Lazy services.

```cs
  [ServiceBinding(typeof(ExampleService))]
  public class ExampleService : IInitializable
  {
    private static readonly Logger Log = LogManager.GetCurrentClassLogger();

    [Inject]
    private ChatService ChatService { get; init; }

    public void Init()
    {
      ChatService.SetChatHearingDistance(ChatChannel.PlayerWhisper, 50f);
    }
  }
  ```

Services can also be injected into runtime created objects:

```cs
  [ServiceBinding(typeof(ExampleService))]
  public class ExampleService : IInitializable
  {
    private static readonly Logger Log = LogManager.GetCurrentClassLogger();

    [Inject]
    private ChatService ChatService { get; init; }

    [Inject]
    private InjectionService InjectionService { get; init; }

    public void Init()
    {
      NotAServiceClass myClass = new NotAServiceClass();
      InjectionService.Inject(myClass); // Injects TlkTable

      myClass = InjectionService.Inject(new NotAServiceClass()); // Can also be assigned.
    }
  }

  public class NotAServiceClass
  {
    private static readonly Logger Log = LogManager.GetCurrentClassLogger();

    [Inject]
    private TlkTable TlkTable { get; init; }

    public void DoStuff()
    {
      Log.Info(TlkTable.GetSimpleString(2));
    }
  }
```

Static properties with the inject attribute are also  injected during startup:

```cs
  public class NotAServiceClass
  {
    private static readonly Logger Log = LogManager.GetCurrentClassLogger();

    [Inject]
    private static TlkTable TlkTable { get; set; }

    public void DoStuff()
    {
      Log.Info(TlkTable.GetSimpleString(2));
    }
  }
  ```