### PR TITLE
Get all creature associates

### DIFF
--- a/src/main/Anvil/API/Object/NwCreature.cs
+++ b/src/main/Anvil/API/Object/NwCreature.cs
@@ -730,37 +730,30 @@ namespace Anvil.API
     /// </summary>
     public IEnumerable<NwCreature> Henchmen
     {
-      get
-      {
-        int i;
-        uint current;
-        const int henchmenType = (int)AssociateType.Henchman;
-
-        for (i = 1, current = NWScript.GetAssociate(henchmenType, this, i); current != Invalid; i++, current = NWScript.GetAssociate(henchmenType, this, i))
-        {
-          yield return current.ToNwObject<NwCreature>();
-        }
-      }
+      get => GetAssociates(AssociateType.Henchman);
     }
 
     /// <summary>
-    /// Gets all associates for this creature.
+    /// Gets all creatures associated with this creature.
     /// </summary>
     public IEnumerable<NwCreature> Associates
     {
       get
       {
-        int i;
-        uint current;
-        var associateTypes = Enum.GetValues(typeof(AssociateType));
+        AssociateType[] allAssociateTypes = Enum.GetValues<AssociateType>();
+        return allAssociateTypes.SelectMany(GetAssociates);
+      }
+    }
 
-        foreach (int type in associateTypes)
-        {
-          for (i = 1, current = NWScript.GetAssociate(type, this, i); current != Invalid; i++, current = NWScript.GetAssociate(type, this, i))
-          {
-            yield return current.ToNwObject<NwCreature>();
-          }
-        }
+    private IEnumerable<NwCreature> GetAssociates(AssociateType associateType)
+    {
+      int i;
+      uint current;
+      int type = (int)associateType;
+
+      for (i = 1, current = NWScript.GetAssociate(type, this, i); current != Invalid; i++, current = NWScript.GetAssociate(type, this, i))
+      {
+        yield return current.ToNwObject<NwCreature>();
       }
     }
 
@@ -1699,14 +1692,15 @@ namespace Anvil.API
     }
 
     /// <summary>
-    /// Gets the associate of this creature with the matching associate type.<br/>
+    /// Gets the first associate of this creature with the matching associate type.<br/>
     /// See <see cref="Henchmen"/> for getting a list of all henchmen associated with this creature.
+    /// See <see cref="Associates"/> for getting a list of all creatures associated with this creature.
     /// </summary>
     /// <param name="associateType">The type of associate to locate.</param>
     /// <returns>The associated creature, otherwise null if this creature does not have an associate of the specified type.</returns>
     public NwCreature GetAssociate(AssociateType associateType)
     {
-      return NWScript.GetAssociate((int)associateType, this).ToNwObject<NwCreature>();
+      return GetAssociates(associateType).FirstOrDefault();
     }
 
     /// <summary>

--- a/src/main/Anvil/API/Object/NwCreature.cs
+++ b/src/main/Anvil/API/Object/NwCreature.cs
@@ -744,6 +744,27 @@ namespace Anvil.API
     }
 
     /// <summary>
+    /// Gets all associates for this creature.
+    /// </summary>
+    public IEnumerable<NwCreature> Associates
+    {
+      get
+      {
+        int i;
+        uint current;
+        var associateTypes = Enum.GetValues(typeof(AssociateType));
+
+        foreach (int type in associateTypes)
+        {
+          for (i = 1, current = NWScript.GetAssociate(type, this, i); current != Invalid; i++, current = NWScript.GetAssociate(type, this, i))
+          {
+            yield return current.ToNwObject<NwCreature>();
+          }
+        }
+      }
+    }
+
+    /// <summary>
     /// Gets this creature's classes.
     /// </summary>
     public IReadOnlyList<ClassType> Classes


### PR DESCRIPTION
`NwCreature` currently offers two ways of getting associates:
* `IEnumerable<NwCreature> Henchmen { get }` yields a list of all henchmen
* `NwCreature GetAssociate(AssociateType associateType() {})` returns a single associate

This makes sense when you consider henchman as the only associate type there can be multiples of. There is however a corner case where a creature can have multiple summons at the moment where a new summon despawns the previous summon on spell cast. This is apparent from the `Area.OnEnter` event where you may loop the number of summoned associates.

As I encounter this corner case while composing a list of all associates of all players in a party, it seems practical to me that Anvil offers this feature. It would certainly save me some time, and possibly others.

As far as the code goes, I've moved the reusable logic out of the `Henchmen` property to a private function. Testing locally checks out OK, but without test coverage I'm not confident that I haven't messed anything up so please look it over if you agree with the changes.