### PR TITLE
Remove redundant logging

### DIFF
--- a/src/main/Anvil/Services/ObjectStorage/ObjectStorageService.cs
+++ b/src/main/Anvil/Services/ObjectStorage/ObjectStorageService.cs
@@ -145,7 +145,6 @@ namespace Anvil.Services
       CResStruct resStruct = CResStruct.FromPointer(pStruct);
 
       string serialized = GetObjectStorage(uuid.m_parent).Serialize();
-      Log.Info(serialized);
       resGff.WriteFieldCExoString(resStruct, serialized.ToExoString(), GffFieldNamePtr);
 
       saveToGffHook.CallOriginal(pUUID, pRes, pStruct);


### PR DESCRIPTION
This line spammed my `anvil.log` with multiples of the lines seen below on login. I'm guessing this is leftover debug logs from development.
```log
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.828] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
I [2021/07/13 11:32:29.831] [Anvil.Services.ObjectStorageService]  
```