### PR TITLE
Fix plugin assemblies not loading on error

### DIFF
--- a/src/main/Anvil/Plugins/PluginLoadContext.cs
+++ b/src/main/Anvil/Plugins/PluginLoadContext.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
 using Anvil.Internal;
@@ -45,16 +44,10 @@ namespace Anvil.Plugins
       string assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
       if (assemblyPath != null)
       {
-        return LoadAssemblyAtPath(assemblyPath);
+        return LoadFromAssemblyPath(assemblyPath);
       }
 
       return null;
-    }
-
-    private Assembly LoadAssemblyAtPath(string assemblyPath)
-    {
-      using MemoryStream memoryStream = new MemoryStream(File.ReadAllBytes(assemblyPath));
-      return LoadFromStream(memoryStream);
     }
 
     protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)


### PR DESCRIPTION
Enables loading plugin `.pdb`s into error contexts, turning
```log
System.NullReferenceException: Object reference not set to an instance of an object.
   at BoP.Service.BootsOfTravelService.DoBootsOfTravelEquip(OnPlayerEquipItem onEquip)
   at Anvil.Services.EventService.EventHandler`1.TryInvoke(T eventData, Action`1 callback) in /home/runner/work/Anvil/Anvil/src/main/Anvil/Services/Events/EventService.EventHandler.cs:line 57
```
into
```log
System.NullReferenceException: Object reference not set to an instance of an object.
   at BoP.Service.BootsOfTravelService.DoBootsOfTravelEquip(OnPlayerEquipItem onEquip) in /home/runner/work/BoP/Service/ItemHandler/BootsOfTravelService.cs:line 21
   at Anvil.Services.EventService.EventHandler`1.TryInvoke(T eventData, Action`1 callback) in /home/runner/work/Anvil/Anvil/src/main/Anvil/Services/Events/EventService.EventHandler.cs:line 57
```
