### PR TITLE
Log Unhandled Exceptions

### DIFF
--- a/src/main/Anvil/AnvilCore.cs
+++ b/src/main/Anvil/AnvilCore.cs
@@ -136,6 +136,7 @@ namespace Anvil
 
       if (!keepLoggerAlive)
       {
+        unhandledExceptionLogger.Dispose();
         loggerManager.Dispose();
       }
     }

--- a/src/main/Anvil/AnvilCore.cs
+++ b/src/main/Anvil/AnvilCore.cs
@@ -26,6 +26,7 @@ namespace Anvil
     private IContainerFactory containerFactory;
     private ITypeLoader typeLoader;
     private LoggerManager loggerManager;
+    private UnhandledExceptionLogger unhandledExceptionLogger;
     private ServiceManager serviceManager;
 
     /// <summary>
@@ -47,6 +48,7 @@ namespace Anvil
       instance.containerFactory = containerFactory;
       instance.typeLoader = typeLoader;
       instance.loggerManager = new LoggerManager();
+      instance.unhandledExceptionLogger = new UnhandledExceptionLogger();
 
       return NWNCore.Init(arg, argLength, instance.interopHandler, instance.interopHandler);
     }
@@ -94,6 +96,7 @@ namespace Anvil
       loggerManager.Init();
       PrelinkNative();
       loggerManager.InitVariables();
+      unhandledExceptionLogger.Init();
 
       AssemblyName assemblyName = Assemblies.Anvil.GetName();
 

--- a/src/main/Anvil/Internal/UnhandledExceptionLogger.cs
+++ b/src/main/Anvil/Internal/UnhandledExceptionLogger.cs
@@ -1,0 +1,45 @@
+using System;
+using NLog;
+
+namespace Anvil.Internal
+{
+  public sealed class UnhandledExceptionLogger : IDisposable
+  {
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    public void Init()
+    {
+      Log.Info("Registering Unhandled Exception Logger");
+      AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+    }
+
+    private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs eventData)
+    {
+      Exception e = (Exception)eventData.ExceptionObject;
+      if (eventData.IsTerminating)
+      {
+        Log.Fatal(e, "Unhandled Exception.");
+      }
+      else
+      {
+        Log.Error(e, "Unhandled Exception.");
+      }
+    }
+
+    public void Dispose()
+    {
+      Unregister();
+      GC.SuppressFinalize(this);
+    }
+
+    ~UnhandledExceptionLogger()
+    {
+      Unregister();
+    }
+
+    private void Unregister()
+    {
+      AppDomain.CurrentDomain.UnhandledException -= OnUnhandledException;
+    }
+  }
+}


### PR DESCRIPTION
Unhandled exceptions are currently consumed by NWNX, and the original stack trace is lost if `stdout` is not observed. Only the native abort signal backtrace is available, which only tells us that the exception came from dotnet:

```
==============================================================
 NWNX 8193.26 (01ef335dae) has crashed. Fatal error: Program aborted (6).
 Please file a bug at https://github.com/nwnxee/unified/issues
==============================================================

  Backtrace:
    /nwn/nwnx/NWNX_Core.so(_ZN7NWNXLib8Platform13GetStackTraceB5cxx11Eh+0x3a) [0x7f80726a9c8a]
    /nwn/nwnx/NWNX_Core.so(nwnx_signal_handler+0x99) [0x7f8072604579]
    /lib/x86_64-linux-gnu/libc.so.6(<UNKNOWN>) [0x7f8072067840]
    /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x10b) [0x7f80720677bb]
    /lib/x86_64-linux-gnu/libc.so.6(abort+0x121) [0x7f8072052535]
    /usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.7/libcoreclr.so(+0x4e582e) [0x7f806505c82e]
    /usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.7/libcoreclr.so(+0x4e577c) [0x7f806505c77c]
    /usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.7/libcoreclr.so(+0x2c795d) [0x7f8064e3e95d]
    /usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.7/libcoreclr.so(+0x2c79e6) [0x7f8064e3e9e6]
    /usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.7/libcoreclr.so(+0x2263fa) [0x7f8064d9d3fa]
    [0x7f7feb4abbb3]
```

This PR attempts to log fatal, unhandled exceptions via NLog, before aborting the runtime.