### PR TITLE
Patch player reference when null

### DIFF
--- a/src/main/Anvil/API/Events/Game/ModuleEvents.cs
+++ b/src/main/Anvil/API/Events/Game/ModuleEvents.cs
@@ -40,6 +40,16 @@ namespace Anvil.API.Events
       {
         get => AcquiredBy;
       }
+
+      public OnAcquireItem()
+      {
+        // Patch player reference due to a reference bug during client enter context
+        // See https://github.com/Beamdog/nwn-issues/issues/367
+        if (AcquiredBy is null && Item.Possessor is NwCreature creature)
+        {
+          AcquiredBy = creature;
+        }
+      }
     }
 
     /// <summary>
@@ -285,6 +295,16 @@ namespace Anvil.API.Events
       NwObject IEvent.Context
       {
         get => Player;
+      }
+
+      public OnPlayerEquipItem()
+      {
+        // Patch player reference due to a reference bug during client enter context
+        // See https://github.com/Beamdog/nwn-issues/issues/367
+        if (Player is null && Item.Possessor is NwCreature creature)
+        {
+          Player = creature;
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #336 

Alternatively we can resolve to always use `Item.Possessor`, but I have only tested the login context and can't say anything about other situations.

Consider this merely as a proposal. If you think we're better off not handling this case feel free to close.