### PR TITLE
Implement GffResource API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 https://github.com/nwn-dotnet/Anvil/compare/v8193.33.1...HEAD
 
 ### Added
-- N/A
+- ResourceManager: Implemented GffResource API.
 
 ### Changed
 - `[ServiceBindingOptions]` - The `BindingPriority` property defines the initialization order of a service. (Higher priority = initialized first).

--- a/NWN.Anvil.csproj.DotSettings
+++ b/NWN.Anvil.csproj.DotSettings
@@ -14,6 +14,9 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Canvil_005Capi_005Cnui_005Cwidgets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Canvil_005Capi_005Cnui_005Cwidgets_005Cdrawlist/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Canvil_005Capi_005Cobject/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Canvil_005Capi_005Cresources/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Canvil_005Capi_005Cresources_005Cgff/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Canvil_005Capi_005Cresources_005Cgff_005Cfields/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Canvil_005Capi_005Cscripts/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Canvil_005Capi_005Cserver/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Canvil_005Capi_005Ctransform/@EntryIndexedValue">True</s:Boolean>

--- a/src/main/Anvil/API/Resources/Gff/Fields/GffResourceField.cs
+++ b/src/main/Anvil/API/Resources/Gff/Fields/GffResourceField.cs
@@ -29,19 +29,207 @@ namespace Anvil.API
       get => throw new InvalidOperationException($"Cannot get child value of {FieldType} with field index.");
     }
 
-    protected virtual string ReadCExoString()
-    {
-      throw new InvalidOperationException($"Cannot convert {FieldType} to string.");
-    }
-
-    public static implicit operator string(GffResourceField field)
-    {
-      return field.ReadCExoString();
-    }
-
     public override string ToString()
     {
-      return ReadCExoString();
+      return Value().ToString();
+    }
+
+    public object Value()
+    {
+      switch (FieldType)
+      {
+        case GffResourceFieldType.Byte when TryReadByte(out byte value):
+          return value;
+        case GffResourceFieldType.Char when TryReadChar(out byte value):
+          return value;
+        case GffResourceFieldType.Word when TryReadWord(out ushort value):
+          return value;
+        case GffResourceFieldType.Short when TryReadShort(out short value):
+          return value;
+        case GffResourceFieldType.DWord when TryReadDWord(out uint value):
+          return value;
+        case GffResourceFieldType.Int when TryReadInt(out int value):
+          return value;
+        case GffResourceFieldType.DWord64 when TryReadDWord64(out ulong value):
+          return value;
+        case GffResourceFieldType.Int64 when TryReadInt64(out long value):
+          return value;
+        case GffResourceFieldType.Float when TryReadFloat(out float value):
+          return value;
+        case GffResourceFieldType.Double when TryReadDouble(out double value):
+          return value;
+        case GffResourceFieldType.CExoString when TryReadCExoString(out string value):
+          return value;
+        case GffResourceFieldType.CResRef when TryReadCResRef(out string value):
+          return value;
+        case GffResourceFieldType.CExoLocString when TryReadCExoLocString(out string value):
+          return value;
+        default:
+          throw new InvalidOperationException($"Cannot convert {FieldType} to value.");
+      }
+    }
+
+    public T Value<T>()
+    {
+      switch (FieldType)
+      {
+        case GffResourceFieldType.Byte when typeof(T) == typeof(byte) && TryReadByte(out byte value):
+          return (T)(object)value;
+        case GffResourceFieldType.Char when typeof(T) == typeof(byte) && TryReadChar(out byte value):
+          return (T)(object)value;
+        case GffResourceFieldType.Word when typeof(T) == typeof(ushort) && TryReadWord(out ushort value):
+          return (T)(object)value;
+        case GffResourceFieldType.Short when typeof(T) == typeof(short) && TryReadShort(out short value):
+          return (T)(object)value;
+        case GffResourceFieldType.DWord when typeof(T) == typeof(uint) && TryReadDWord(out uint value):
+          return (T)(object)value;
+        case GffResourceFieldType.Int when typeof(T) == typeof(int) && TryReadInt(out int value):
+          return (T)(object)value;
+        case GffResourceFieldType.DWord64 when typeof(T) == typeof(ulong) && TryReadDWord64(out ulong value):
+          return (T)(object)value;
+        case GffResourceFieldType.Int64 when typeof(T) == typeof(long) && TryReadInt64(out long value):
+          return (T)(object)value;
+        case GffResourceFieldType.Float when typeof(T) == typeof(float) && TryReadFloat(out float value):
+          return (T)(object)value;
+        case GffResourceFieldType.Double when typeof(T) == typeof(double) && TryReadDouble(out double value):
+          return (T)(object)value;
+        case GffResourceFieldType.CExoString when typeof(T) == typeof(string) && TryReadCExoString(out string value):
+          return (T)(object)value;
+        case GffResourceFieldType.CResRef when typeof(T) == typeof(string) && TryReadCResRef(out string value):
+          return (T)(object)value;
+        case GffResourceFieldType.CExoLocString when typeof(T) == typeof(string) && TryReadCExoLocString(out string value):
+          return (T)(object)value;
+        default:
+          throw new InvalidOperationException($"Cannot convert {FieldType} to {typeof(T).Name}");
+      }
+    }
+
+    public static explicit operator byte(GffResourceField field)
+    {
+      return field.Value<byte>();
+    }
+
+    public static explicit operator ushort(GffResourceField field)
+    {
+      return field.Value<ushort>();
+    }
+
+    public static explicit operator short(GffResourceField field)
+    {
+      return field.Value<short>();
+    }
+
+    public static explicit operator uint(GffResourceField field)
+    {
+      return field.Value<uint>();
+    }
+
+    public static explicit operator int(GffResourceField field)
+    {
+      return field.Value<int>();
+    }
+
+    public static explicit operator ulong(GffResourceField field)
+    {
+      return field.Value<ulong>();
+    }
+
+    public static explicit operator long(GffResourceField field)
+    {
+      return field.Value<long>();
+    }
+
+    public static explicit operator float(GffResourceField field)
+    {
+      return field.Value<float>();
+    }
+
+    public static explicit operator double(GffResourceField field)
+    {
+      return field.Value<double>();
+    }
+
+    public static explicit operator string(GffResourceField field)
+    {
+      return field.Value<string>();
+    }
+
+    public virtual bool TryReadCExoString(out string value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadCResRef(out string value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadInt(out int value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadInt64(out long value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadByte(out byte value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadCExoLocString(out string value, int id = 0, Gender gender = Gender.Male)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadChar(out byte value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadWord(out ushort value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadDWord(out uint value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadDWord64(out ulong value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadFloat(out float value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadShort(out short value)
+    {
+      value = default;
+      return false;
+    }
+
+    public virtual bool TryReadDouble(out double value)
+    {
+      value = default;
+      return false;
     }
 
     public void Dispose()

--- a/src/main/Anvil/API/Resources/Gff/Fields/GffResourceField.cs
+++ b/src/main/Anvil/API/Resources/Gff/Fields/GffResourceField.cs
@@ -1,0 +1,114 @@
+using System;
+using NWN.Native.API;
+
+namespace Anvil.API
+{
+  public abstract unsafe class GffResourceField : IDisposable
+  {
+    protected CResGFF ResGff { get; private set; }
+
+    protected GffResourceField(CResGFF resGff)
+    {
+      ResGff = resGff;
+    }
+
+    ~GffResourceField()
+    {
+      Dispose(false);
+    }
+
+    public abstract GffResourceFieldType FieldType { get; }
+
+    public virtual GffResourceField this[string key]
+    {
+      get => throw new InvalidOperationException($"Cannot get child value of {FieldType} with field key.");
+    }
+
+    public virtual GffResourceField this[uint index]
+    {
+      get => throw new InvalidOperationException($"Cannot get child value of {FieldType} with field index.");
+    }
+
+    protected virtual string ReadCExoString()
+    {
+      throw new InvalidOperationException($"Cannot convert {FieldType} to string.");
+    }
+
+    public static implicit operator string(GffResourceField field)
+    {
+      return field.ReadCExoString();
+    }
+
+    public override string ToString()
+    {
+      return ReadCExoString();
+    }
+
+    public void Dispose()
+    {
+      Dispose(true);
+    }
+
+    internal static GffResourceField Create(CResGFF resGff, CResStruct resStruct, string fieldId)
+    {
+      byte* fieldIdPtr = fieldId.GetNullTerminatedString();
+      uint index = resGff.GetFieldByLabel(resStruct, fieldIdPtr);
+      return Create(resGff, resStruct, index, fieldIdPtr);
+    }
+
+    internal static GffResourceField Create(CResGFF resGff, CResStruct resStruct, uint fieldIndex)
+    {
+      byte* fieldId = resGff.GetFieldStringID(resStruct, fieldIndex);
+      if (fieldId == null)
+      {
+        return null;
+      }
+
+      return Create(resGff, resStruct, fieldIndex, fieldId);
+    }
+
+    internal static GffResourceField Create(CResGFF resGff, CResStruct resStruct, uint fieldIndex, byte* fieldId)
+    {
+      GffResourceFieldType fieldType = (GffResourceFieldType)resGff.GetFieldType(resStruct, fieldId, fieldIndex);
+      if (!Enum.IsDefined(fieldType)) // User specified struct type.
+      {
+        fieldType = GffResourceFieldType.Struct;
+      }
+
+      switch (fieldType)
+      {
+        case GffResourceFieldType.Struct:
+          CResStruct structField = new CResStruct();
+          if (resGff.GetStructFromStruct(structField, resStruct, fieldId).ToBool())
+          {
+            return new GffResourceFieldStruct(resGff, resStruct);
+          }
+
+          break;
+        case GffResourceFieldType.List:
+          CResList listField = new CResList();
+          if (resGff.GetList(listField, resStruct, fieldId).ToBool())
+          {
+            return new GffResourceFieldList(resGff, listField, resGff.GetListCount(listField));
+          }
+
+          break;
+        default:
+          return new GffResourceFieldValue(resGff, resStruct, fieldId);
+      }
+
+      return null;
+    }
+
+    private void Dispose(bool disposing)
+    {
+      ResGff?.Dispose();
+      ResGff = null;
+
+      if (disposing)
+      {
+        GC.SuppressFinalize(this);
+      }
+    }
+  }
+}

--- a/src/main/Anvil/API/Resources/Gff/Fields/GffResourceField.cs
+++ b/src/main/Anvil/API/Resources/Gff/Fields/GffResourceField.cs
@@ -1,240 +1,21 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using NWN.Native.API;
 
 namespace Anvil.API
 {
-  public abstract unsafe class GffResourceField : IDisposable
+  /// <summary>
+  /// A property/field in a <see cref="GffResource"/>.
+  /// </summary>
+  public abstract unsafe class GffResourceField
   {
-    protected CResGFF ResGff { get; private set; }
+    protected readonly CResGFF ResGff;
 
     protected GffResourceField(CResGFF resGff)
     {
       ResGff = resGff;
-    }
-
-    ~GffResourceField()
-    {
-      Dispose(false);
-    }
-
-    public abstract GffResourceFieldType FieldType { get; }
-
-    public virtual GffResourceField this[string key]
-    {
-      get => throw new InvalidOperationException($"Cannot get child value of {FieldType} with field key.");
-    }
-
-    public virtual GffResourceField this[uint index]
-    {
-      get => throw new InvalidOperationException($"Cannot get child value of {FieldType} with field index.");
-    }
-
-    public override string ToString()
-    {
-      return Value().ToString();
-    }
-
-    public object Value()
-    {
-      switch (FieldType)
-      {
-        case GffResourceFieldType.Byte when TryReadByte(out byte value):
-          return value;
-        case GffResourceFieldType.Char when TryReadChar(out byte value):
-          return value;
-        case GffResourceFieldType.Word when TryReadWord(out ushort value):
-          return value;
-        case GffResourceFieldType.Short when TryReadShort(out short value):
-          return value;
-        case GffResourceFieldType.DWord when TryReadDWord(out uint value):
-          return value;
-        case GffResourceFieldType.Int when TryReadInt(out int value):
-          return value;
-        case GffResourceFieldType.DWord64 when TryReadDWord64(out ulong value):
-          return value;
-        case GffResourceFieldType.Int64 when TryReadInt64(out long value):
-          return value;
-        case GffResourceFieldType.Float when TryReadFloat(out float value):
-          return value;
-        case GffResourceFieldType.Double when TryReadDouble(out double value):
-          return value;
-        case GffResourceFieldType.CExoString when TryReadCExoString(out string value):
-          return value;
-        case GffResourceFieldType.CResRef when TryReadCResRef(out string value):
-          return value;
-        case GffResourceFieldType.CExoLocString when TryReadCExoLocString(out string value):
-          return value;
-        default:
-          throw new InvalidOperationException($"Cannot convert {FieldType} to value.");
-      }
-    }
-
-    public T Value<T>()
-    {
-      switch (FieldType)
-      {
-        case GffResourceFieldType.Byte when typeof(T) == typeof(byte) && TryReadByte(out byte value):
-          return (T)(object)value;
-        case GffResourceFieldType.Char when typeof(T) == typeof(byte) && TryReadChar(out byte value):
-          return (T)(object)value;
-        case GffResourceFieldType.Word when typeof(T) == typeof(ushort) && TryReadWord(out ushort value):
-          return (T)(object)value;
-        case GffResourceFieldType.Short when typeof(T) == typeof(short) && TryReadShort(out short value):
-          return (T)(object)value;
-        case GffResourceFieldType.DWord when typeof(T) == typeof(uint) && TryReadDWord(out uint value):
-          return (T)(object)value;
-        case GffResourceFieldType.Int when typeof(T) == typeof(int) && TryReadInt(out int value):
-          return (T)(object)value;
-        case GffResourceFieldType.DWord64 when typeof(T) == typeof(ulong) && TryReadDWord64(out ulong value):
-          return (T)(object)value;
-        case GffResourceFieldType.Int64 when typeof(T) == typeof(long) && TryReadInt64(out long value):
-          return (T)(object)value;
-        case GffResourceFieldType.Float when typeof(T) == typeof(float) && TryReadFloat(out float value):
-          return (T)(object)value;
-        case GffResourceFieldType.Double when typeof(T) == typeof(double) && TryReadDouble(out double value):
-          return (T)(object)value;
-        case GffResourceFieldType.CExoString when typeof(T) == typeof(string) && TryReadCExoString(out string value):
-          return (T)(object)value;
-        case GffResourceFieldType.CResRef when typeof(T) == typeof(string) && TryReadCResRef(out string value):
-          return (T)(object)value;
-        case GffResourceFieldType.CExoLocString when typeof(T) == typeof(string) && TryReadCExoLocString(out string value):
-          return (T)(object)value;
-        default:
-          throw new InvalidOperationException($"Cannot convert {FieldType} to {typeof(T).Name}");
-      }
-    }
-
-    public static explicit operator byte(GffResourceField field)
-    {
-      return field.Value<byte>();
-    }
-
-    public static explicit operator ushort(GffResourceField field)
-    {
-      return field.Value<ushort>();
-    }
-
-    public static explicit operator short(GffResourceField field)
-    {
-      return field.Value<short>();
-    }
-
-    public static explicit operator uint(GffResourceField field)
-    {
-      return field.Value<uint>();
-    }
-
-    public static explicit operator int(GffResourceField field)
-    {
-      return field.Value<int>();
-    }
-
-    public static explicit operator ulong(GffResourceField field)
-    {
-      return field.Value<ulong>();
-    }
-
-    public static explicit operator long(GffResourceField field)
-    {
-      return field.Value<long>();
-    }
-
-    public static explicit operator float(GffResourceField field)
-    {
-      return field.Value<float>();
-    }
-
-    public static explicit operator double(GffResourceField field)
-    {
-      return field.Value<double>();
-    }
-
-    public static explicit operator string(GffResourceField field)
-    {
-      return field.Value<string>();
-    }
-
-    public virtual bool TryReadCExoString(out string value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadCResRef(out string value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadInt(out int value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadInt64(out long value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadByte(out byte value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadCExoLocString(out string value, int id = 0, Gender gender = Gender.Male)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadChar(out byte value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadWord(out ushort value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadDWord(out uint value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadDWord64(out ulong value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadFloat(out float value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadShort(out short value)
-    {
-      value = default;
-      return false;
-    }
-
-    public virtual bool TryReadDouble(out double value)
-    {
-      value = default;
-      return false;
-    }
-
-    public void Dispose()
-    {
-      Dispose(true);
     }
 
     internal static GffResourceField Create(CResGFF resGff, CResStruct resStruct, string fieldId)
@@ -288,15 +69,191 @@ namespace Anvil.API
       return null;
     }
 
-    private void Dispose(bool disposing)
-    {
-      ResGff?.Dispose();
-      ResGff = null;
+    /// <summary>
+    /// Gets the GFF field type.
+    /// </summary>
+    public abstract GffResourceFieldType FieldType { get; }
 
-      if (disposing)
+    /// <summary>
+    /// Gets whether this field contains child values.
+    /// </summary>
+    public bool HasChildren
+    {
+      get => this is IEnumerable;
+    }
+
+    /// <summary>
+    /// Gets the number of child fields.
+    /// </summary>
+    public virtual int Count { get => 0; }
+
+    /// <summary>
+    /// Gets the child <see cref="GffResourceField"/> at the specified index.
+    /// </summary>
+    public virtual GffResourceField this[int index]
+    {
+      get => throw new InvalidOperationException($"Cannot get child value of {FieldType} with field index.");
+    }
+
+    /// <summary>
+    /// Gets the child <see cref="GffResourceField"/> with the specified key.
+    /// </summary>
+    public virtual GffResourceField this[string key]
+    {
+      get => throw new InvalidOperationException($"Cannot get child value of {FieldType} with field key.");
+    }
+
+    /// <summary>
+    /// If this field is a struct, gets an enumerable of the struct's keys.<br/>
+    /// Otherwise, returns an empty enumerable.
+    /// </summary>
+    public virtual IEnumerable<string> Keys { get; } = Enumerable.Empty<string>();
+
+    /// <summary>
+    /// If this field is an array, gets an enumerable of the array's values.<br/>
+    /// If this field is a struct, gets an enumerable of the struct's values.<br/>
+    /// Otherwise, returns an empty enumerable.
+    /// </summary>
+    public virtual IEnumerable<GffResourceField> Values { get; } = Enumerable.Empty<GffResourceField>();
+
+    /// <summary>
+    /// If this field is a struct, gets an enumerable of the key/values pairs.<br/>
+    /// Otherwise, returns an empty enumerable.
+    /// </summary>
+    public virtual IEnumerable<KeyValuePair<string, GffResourceField>> EntrySet { get; } = Enumerable.Empty<KeyValuePair<string, GffResourceField>>();
+
+    /// <summary>
+    /// If this field is a <see cref="GffResourceFieldStruct"/>, determines if the specified key exists in the structure.
+    /// </summary>
+    /// <param name="key">The key to locate in the <see cref="GffResourceFieldStruct"/>./</param>
+    /// <returns>True if the field is a <see cref="GffResourceFieldStruct"/> and the key exists. Otherwise, false.</returns>
+    public virtual bool ContainsKey(string key)
+    {
+      return false;
+    }
+
+    /// <summary>
+    /// If this field is a <see cref="GffResourceFieldStruct"/>, gets the value associated with the specified key.
+    /// </summary>
+    /// <param name="key">The key of the value to get./</param>
+    /// <param name="value">If the method runs successfully (returns true), this output parameter will contain the associated value.</param>
+    /// <returns>True if the field is a <see cref="GffResourceFieldStruct"/> and the key exists. Otherwise, false.</returns>
+    public virtual bool TryGetValue(string key, out GffResourceField value)
+    {
+      value = default;
+      return false;
+    }
+
+    /// <summary>
+    /// Gets the value of this field.
+    /// </summary>
+    /// <returns>The value associated with this <see cref="GffResourceField"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if this field is not a standard value type.</exception>
+    public object Value()
+    {
+      if (GetValueInternal(out object value))
       {
-        GC.SuppressFinalize(this);
+        return value;
       }
+
+      throw new InvalidOperationException($"Cannot convert {FieldType} to value.");
+    }
+
+    /// <summary>
+    /// Gets the value of this field.
+    /// </summary>
+    /// <typeparam name="T">The field value type.</typeparam>
+    /// <returns>The value associated with this <see cref="GffResourceField"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if this field is not a standard value type, or an invalid generic type was specified..</exception>
+    public T Value<T>()
+    {
+      if (GetValueInternal(out object value, typeof(T)))
+      {
+        return (T)value;
+      }
+      else
+      {
+        throw new InvalidOperationException($"Cannot convert {FieldType} to {typeof(T).Name}");
+      }
+    }
+
+    /// <summary>
+    /// Gets the value of this field.
+    /// </summary>
+    /// <returns>The value associated with this <see cref="GffResourceField"/>. Returns null if the value is a list or struct.</returns>
+    public object ValueOrDefault()
+    {
+      return GetValueInternal(out object value) ? value : default;
+    }
+
+    /// <summary>
+    /// Gets the value of this field.
+    /// </summary>
+    /// <returns>The value associated with this <see cref="GffResourceField"/>. Returns null if the value is a list or struct, or does not match the specified type.</returns>
+    public T ValueOrDefault<T>()
+    {
+      return GetValueInternal(out object value, typeof(T)) ? (T)value : default;
+    }
+
+    public sealed override string ToString()
+    {
+      return Value().ToString();
+    }
+
+    protected virtual bool GetValueInternal(out object value, Type requestedType = null)
+    {
+      value = null;
+      return false;
+    }
+
+    public static explicit operator byte(GffResourceField field)
+    {
+      return field.Value<byte>();
+    }
+
+    public static explicit operator ushort(GffResourceField field)
+    {
+      return field.Value<ushort>();
+    }
+
+    public static explicit operator short(GffResourceField field)
+    {
+      return field.Value<short>();
+    }
+
+    public static explicit operator uint(GffResourceField field)
+    {
+      return field.Value<uint>();
+    }
+
+    public static explicit operator int(GffResourceField field)
+    {
+      return field.Value<int>();
+    }
+
+    public static explicit operator ulong(GffResourceField field)
+    {
+      return field.Value<ulong>();
+    }
+
+    public static explicit operator long(GffResourceField field)
+    {
+      return field.Value<long>();
+    }
+
+    public static explicit operator float(GffResourceField field)
+    {
+      return field.Value<float>();
+    }
+
+    public static explicit operator double(GffResourceField field)
+    {
+      return field.Value<double>();
+    }
+
+    public static explicit operator string(GffResourceField field)
+    {
+      return field.Value<string>();
     }
   }
 }

--- a/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldList.cs
+++ b/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldList.cs
@@ -1,52 +1,49 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using NWN.Native.API;
 
 namespace Anvil.API
 {
+  /// <summary>
+  /// A <see cref="GffResourceField"/> containing a list of <see cref="GffResourceFieldStruct"/> values.
+  /// </summary>
   public sealed class GffResourceFieldList : GffResourceField, IReadOnlyList<GffResourceFieldStruct>
   {
-    private readonly CResList list;
-
-    public GffResourceFieldList(CResGFF resGff, CResList list, uint count) : base(resGff)
-    {
-      this.list = list;
-      Count = (int)count;
-    }
+    private readonly List<GffResourceFieldStruct> children = new List<GffResourceFieldStruct>();
 
     public override GffResourceFieldType FieldType
     {
       get => GffResourceFieldType.List;
     }
 
-    public int Count { get; }
-
-    public GffResourceFieldStruct this[int index]
+    internal GffResourceFieldList(CResGFF resGff, CResList list, uint count) : base(resGff)
     {
-      get
+      for (uint i = 0; i < count; i++)
       {
-        if (index >= Count)
-        {
-          throw new IndexOutOfRangeException("Index was outside the bounds of the list.");
-        }
-
         CResStruct resStruct = new CResStruct();
-        return ResGff.GetListElement(resStruct, list, (uint)index).ToBool() ? new GffResourceFieldStruct(ResGff, resStruct) : null;
+        GffResourceFieldStruct childField = ResGff.GetListElement(resStruct, list, i).ToBool() ? new GffResourceFieldStruct(ResGff, resStruct) : null;
+        children.Add(childField);
       }
     }
 
-    public override GffResourceField this[uint index]
+    public override int Count
     {
-      get => this[(int)index];
+      get => children.Count;
+    }
+
+    public override GffResourceFieldStruct this[int index]
+    {
+      get => children[index];
+    }
+
+    public override IEnumerable<GffResourceFieldStruct> Values
+    {
+      get => children;
     }
 
     public IEnumerator<GffResourceFieldStruct> GetEnumerator()
     {
-      for (int i = 0; i < Count; i++)
-      {
-        yield return this[i];
-      }
+      return children.GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()

--- a/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldList.cs
+++ b/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldList.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NWN.Native.API;
+
+namespace Anvil.API
+{
+  public sealed class GffResourceFieldList : GffResourceField, IReadOnlyList<GffResourceFieldStruct>
+  {
+    private readonly CResList list;
+
+    public GffResourceFieldList(CResGFF resGff, CResList list, uint count) : base(resGff)
+    {
+      this.list = list;
+      Count = (int)count;
+    }
+
+    public override GffResourceFieldType FieldType
+    {
+      get => GffResourceFieldType.List;
+    }
+
+    public int Count { get; }
+
+    public GffResourceFieldStruct this[int index]
+    {
+      get
+      {
+        if (index >= Count)
+        {
+          throw new IndexOutOfRangeException("Index was outside the bounds of the list.");
+        }
+
+        CResStruct resStruct = new CResStruct();
+        return ResGff.GetListElement(resStruct, list, (uint)index).ToBool() ? new GffResourceFieldStruct(ResGff, resStruct) : null;
+      }
+    }
+
+    public override GffResourceField this[uint index]
+    {
+      get => this[(int)index];
+    }
+
+    public IEnumerator<GffResourceFieldStruct> GetEnumerator()
+    {
+      for (int i = 0; i < Count; i++)
+      {
+        yield return this[i];
+      }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+      return GetEnumerator();
+    }
+  }
+}

--- a/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldStruct.cs
+++ b/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldStruct.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using System.Collections.Generic;
+using NWN.Native.API;
+
+namespace Anvil.API
+{
+  public sealed unsafe class GffResourceFieldStruct : GffResourceField, IReadOnlyDictionary<string, GffResourceField>
+  {
+    private readonly List<string> keys = new List<string>();
+    private readonly List<GffResourceField> values = new List<GffResourceField>();
+
+    private readonly Dictionary<string, GffResourceField> fieldLookup = new Dictionary<string, GffResourceField>();
+
+    public GffResourceFieldStruct(CResGFF resGff, CResStruct resStruct) : base(resGff)
+    {
+      Count = (int)resGff.GetFieldCount(resStruct);
+
+      for (uint i = 0; i < Count; i++)
+      {
+        byte* fieldIdPtr = ResGff.GetFieldLabel(resStruct, i);
+        string key = StringHelper.ReadNullTerminatedString(fieldIdPtr);
+        GffResourceField value = Create(resGff, resStruct, i, fieldIdPtr);
+
+        keys.Add(key);
+        values.Add(value);
+        fieldLookup.Add(key, value);
+      }
+    }
+
+    public override GffResourceFieldType FieldType
+    {
+      get => GffResourceFieldType.Struct;
+    }
+
+    public int Count { get; }
+
+    IEnumerable<string> IReadOnlyDictionary<string, GffResourceField>.Keys
+    {
+      get => keys;
+    }
+
+    IEnumerable<GffResourceField> IReadOnlyDictionary<string, GffResourceField>.Values
+    {
+      get => values;
+    }
+
+    public bool ContainsKey(string key)
+    {
+      return fieldLookup.ContainsKey(key);
+    }
+
+    public bool TryGetValue(string key, out GffResourceField value)
+    {
+      return fieldLookup.TryGetValue(key, out value);
+    }
+
+    public override GffResourceField this[string key]
+    {
+      get => fieldLookup[key];
+    }
+
+    public override GffResourceField this[uint index]
+    {
+      get => fieldLookup[keys[(int)index]];
+    }
+
+    public IEnumerator<KeyValuePair<string, GffResourceField>> GetEnumerator()
+    {
+      for (int i = 0; i < keys.Count; i++)
+      {
+        yield return new KeyValuePair<string, GffResourceField>(keys[i], values[i]);
+      }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+      return GetEnumerator();
+    }
+  }
+}

--- a/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldType.cs
+++ b/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldType.cs
@@ -1,0 +1,22 @@
+namespace Anvil.API
+{
+  public enum GffResourceFieldType : uint
+  {
+    Byte = 0x0,
+    Char = 0x1,
+    Word = 0x2,
+    Short = 0x3,
+    DWord = 0x4,
+    Int = 0x5,
+    DWord64 = 0x6,
+    Int64 = 0x7,
+    Float = 0x8,
+    Double = 0x9,
+    CExoString = 0xA,
+    CResRef = 0xB,
+    CExoLocString = 0xC,
+    Void = 0xD,
+    Struct = 0xE,
+    List = 0xF,
+  }
+}

--- a/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldValue.cs
+++ b/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldValue.cs
@@ -3,107 +3,159 @@ using NWN.Native.API;
 
 namespace Anvil.API
 {
+  /// <summary>
+  /// A regular <see cref="GffResourceField"/> containing a primitive value.
+  /// </summary>
   public sealed unsafe class GffResourceFieldValue : GffResourceField
   {
     private readonly CResStruct parentStruct;
     private readonly byte* fieldId;
-
-    public GffResourceFieldValue(CResGFF resGff, CResStruct parentStruct, byte* fieldId) : base(resGff)
-    {
-      this.parentStruct = parentStruct;
-      this.fieldId = fieldId;
-    }
 
     public override GffResourceFieldType FieldType
     {
       get => (GffResourceFieldType)ResGff.GetFieldType(parentStruct, fieldId);
     }
 
-    public override bool TryReadCExoString(out string value)
+    internal GffResourceFieldValue(CResGFF resGff, CResStruct parentStruct, byte* fieldId) : base(resGff)
+    {
+      this.parentStruct = parentStruct;
+      this.fieldId = fieldId;
+    }
+
+    protected override bool GetValueInternal(out object value, Type requestedType = null)
+    {
+      switch (FieldType)
+      {
+        case GffResourceFieldType.Byte when (requestedType == null || requestedType == typeof(byte)) && TryReadByte(out byte readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.Char when (requestedType == null || requestedType == typeof(byte)) && TryReadChar(out byte readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.Word when (requestedType == null || requestedType == typeof(ushort)) && TryReadWord(out ushort readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.Short when (requestedType == null || requestedType == typeof(short)) && TryReadShort(out short readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.DWord when (requestedType == null || requestedType == typeof(uint)) && TryReadDWord(out uint readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.Int when (requestedType == null || requestedType == typeof(int)) && TryReadInt(out int readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.DWord64 when (requestedType == null || requestedType == typeof(ulong)) && TryReadDWord64(out ulong readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.Int64 when (requestedType == null || requestedType == typeof(long)) && TryReadInt64(out long readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.Float when (requestedType == null || requestedType == typeof(float)) && TryReadFloat(out float readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.Double when (requestedType == null || requestedType == typeof(double)) && TryReadDouble(out double readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.CExoString when (requestedType == null || requestedType == typeof(string)) && TryReadCExoString(out string readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.CResRef when (requestedType == null || requestedType == typeof(string)) && TryReadCResRef(out string readValue):
+          value = readValue;
+          return true;
+        case GffResourceFieldType.CExoLocString when (requestedType == null || requestedType == typeof(string)) && TryReadCExoLocString(out string readValue):
+          value = readValue;
+          return true;
+        default:
+          value = null;
+          return false;
+      }
+    }
+
+    public bool TryReadCExoString(out string value)
     {
       int bSuccess;
       value = ResGff.ReadFieldCExoString(parentStruct, fieldId, &bSuccess).ToString();
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadCResRef(out string value)
+    public bool TryReadCResRef(out string value)
     {
       int bSuccess;
       value = ResGff.ReadFieldCResRef(parentStruct, fieldId, &bSuccess).ToString();
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadInt(out int value)
+    public bool TryReadInt(out int value)
     {
       int bSuccess;
       value = ResGff.ReadFieldINT(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadInt64(out long value)
+    public bool TryReadInt64(out long value)
     {
       int bSuccess;
       value = ResGff.ReadFieldINT64(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadByte(out byte value)
+    public bool TryReadByte(out byte value)
     {
       int bSuccess;
       value = ResGff.ReadFieldBYTE(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadCExoLocString(out string value, int id = 0, Gender gender = Gender.Male)
+    public bool TryReadCExoLocString(out string value, int id = 0, Gender gender = Gender.Male)
     {
       int bSuccess;
       value = ResGff.ReadFieldCExoLocString(parentStruct, fieldId, &bSuccess).ExtractLocString(id, (byte)gender);
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadChar(out byte value)
+    public bool TryReadChar(out byte value)
     {
       int bSuccess;
       value = ResGff.ReadFieldCHAR(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadWord(out ushort value)
+    public bool TryReadWord(out ushort value)
     {
       int bSuccess;
       value = ResGff.ReadFieldWORD(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadDWord(out uint value)
+    public bool TryReadDWord(out uint value)
     {
       int bSuccess;
       value = ResGff.ReadFieldDWORD(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadDWord64(out ulong value)
+    public bool TryReadDWord64(out ulong value)
     {
       int bSuccess;
       value = ResGff.ReadFieldDWORD64(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadFloat(out float value)
+    public bool TryReadFloat(out float value)
     {
       int bSuccess;
       value = ResGff.ReadFieldFLOAT(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadShort(out short value)
+    public bool TryReadShort(out short value)
     {
       int bSuccess;
       value = ResGff.ReadFieldSHORT(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public override bool TryReadDouble(out double value)
+    public bool TryReadDouble(out double value)
     {
       int bSuccess;
       value = ResGff.ReadFieldDOUBLE(parentStruct, fieldId, &bSuccess);

--- a/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldValue.cs
+++ b/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldValue.cs
@@ -1,0 +1,117 @@
+using NWN.Native.API;
+
+namespace Anvil.API
+{
+  public sealed unsafe class GffResourceFieldValue : GffResourceField
+  {
+    private readonly CResStruct parentStruct;
+    private readonly byte* fieldId;
+
+    public GffResourceFieldValue(CResGFF resGff, CResStruct parentStruct, byte* fieldId) : base(resGff)
+    {
+      this.parentStruct = parentStruct;
+      this.fieldId = fieldId;
+    }
+
+    public override GffResourceFieldType FieldType
+    {
+      get => (GffResourceFieldType)ResGff.GetFieldType(parentStruct, fieldId);
+    }
+
+    protected override string ReadCExoString()
+    {
+      return TryReadCExoString(out string retVal) ? retVal : null;
+    }
+
+    public bool TryReadCExoString(out string value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldCExoString(parentStruct, fieldId, &bSuccess).ToString();
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadCResRef(out CResRef value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldCResRef(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadInt(out int value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldINT(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadInt64(out long value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldINT64(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadByte(out byte value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldBYTE(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadCExoLocString(out CExoLocString value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldCExoLocString(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadChar(out byte value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldCHAR(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadWord(out ushort value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldWORD(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadDWord(out uint value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldDWORD(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadDWord64(out ulong value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldDWORD64(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadFloat(out float value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldFLOAT(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadShort(out short value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldSHORT(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+
+    public bool TryReadDouble(out double value)
+    {
+      int bSuccess;
+      value = ResGff.ReadFieldDOUBLE(parentStruct, fieldId, &bSuccess);
+      return bSuccess.ToBool();
+    }
+  }
+}

--- a/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldValue.cs
+++ b/src/main/Anvil/API/Resources/Gff/Fields/GffResourceFieldValue.cs
@@ -1,3 +1,4 @@
+using System;
 using NWN.Native.API;
 
 namespace Anvil.API
@@ -18,96 +19,91 @@ namespace Anvil.API
       get => (GffResourceFieldType)ResGff.GetFieldType(parentStruct, fieldId);
     }
 
-    protected override string ReadCExoString()
-    {
-      return TryReadCExoString(out string retVal) ? retVal : null;
-    }
-
-    public bool TryReadCExoString(out string value)
+    public override bool TryReadCExoString(out string value)
     {
       int bSuccess;
       value = ResGff.ReadFieldCExoString(parentStruct, fieldId, &bSuccess).ToString();
       return bSuccess.ToBool();
     }
 
-    public bool TryReadCResRef(out CResRef value)
+    public override bool TryReadCResRef(out string value)
     {
       int bSuccess;
-      value = ResGff.ReadFieldCResRef(parentStruct, fieldId, &bSuccess);
+      value = ResGff.ReadFieldCResRef(parentStruct, fieldId, &bSuccess).ToString();
       return bSuccess.ToBool();
     }
 
-    public bool TryReadInt(out int value)
+    public override bool TryReadInt(out int value)
     {
       int bSuccess;
       value = ResGff.ReadFieldINT(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public bool TryReadInt64(out long value)
+    public override bool TryReadInt64(out long value)
     {
       int bSuccess;
       value = ResGff.ReadFieldINT64(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public bool TryReadByte(out byte value)
+    public override bool TryReadByte(out byte value)
     {
       int bSuccess;
       value = ResGff.ReadFieldBYTE(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public bool TryReadCExoLocString(out CExoLocString value)
+    public override bool TryReadCExoLocString(out string value, int id = 0, Gender gender = Gender.Male)
     {
       int bSuccess;
-      value = ResGff.ReadFieldCExoLocString(parentStruct, fieldId, &bSuccess);
+      value = ResGff.ReadFieldCExoLocString(parentStruct, fieldId, &bSuccess).ExtractLocString(id, (byte)gender);
       return bSuccess.ToBool();
     }
 
-    public bool TryReadChar(out byte value)
+    public override bool TryReadChar(out byte value)
     {
       int bSuccess;
       value = ResGff.ReadFieldCHAR(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public bool TryReadWord(out ushort value)
+    public override bool TryReadWord(out ushort value)
     {
       int bSuccess;
       value = ResGff.ReadFieldWORD(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public bool TryReadDWord(out uint value)
+    public override bool TryReadDWord(out uint value)
     {
       int bSuccess;
       value = ResGff.ReadFieldDWORD(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public bool TryReadDWord64(out ulong value)
+    public override bool TryReadDWord64(out ulong value)
     {
       int bSuccess;
       value = ResGff.ReadFieldDWORD64(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public bool TryReadFloat(out float value)
+    public override bool TryReadFloat(out float value)
     {
       int bSuccess;
       value = ResGff.ReadFieldFLOAT(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public bool TryReadShort(out short value)
+    public override bool TryReadShort(out short value)
     {
       int bSuccess;
       value = ResGff.ReadFieldSHORT(parentStruct, fieldId, &bSuccess);
       return bSuccess.ToBool();
     }
 
-    public bool TryReadDouble(out double value)
+    public override bool TryReadDouble(out double value)
     {
       int bSuccess;
       value = ResGff.ReadFieldDOUBLE(parentStruct, fieldId, &bSuccess);

--- a/src/main/Anvil/API/Resources/Gff/GffResource.cs
+++ b/src/main/Anvil/API/Resources/Gff/GffResource.cs
@@ -12,7 +12,7 @@ namespace Anvil.API
     {
       this.resGff = resGff;
 
-      FileType = resGff.m_pFileType.ReadFixedLengthString();
+      FileType = resGff.m_pFileType.ReadFixedLengthString().Trim();
 
       rootStruct = new CResStruct();
       if (!resGff.GetTopLevelStruct(rootStruct).ToBool())
@@ -26,13 +26,22 @@ namespace Anvil.API
       Dispose(false);
     }
 
+    /// <summary>
+    /// Gets the file type/extension of this <see cref="GffResource"/>.
+    /// </summary>
     public string FileType { get; }
 
+    /// <summary>
+    /// Gets the child <see cref="GffResourceField"/> at the specified index.
+    /// </summary>
     public GffResourceField this[int index]
     {
       get => GffResourceField.Create(resGff, rootStruct, (uint)index);
     }
 
+    /// <summary>
+    /// Gets the child <see cref="GffResourceField"/> with the specified key.
+    /// </summary>
     public GffResourceField this[string index]
     {
       get => GffResourceField.Create(resGff, rootStruct, index);

--- a/src/main/Anvil/API/Resources/Gff/GffResource.cs
+++ b/src/main/Anvil/API/Resources/Gff/GffResource.cs
@@ -3,7 +3,7 @@ using NWN.Native.API;
 
 namespace Anvil.API
 {
-  public sealed class GffResource
+  public sealed class GffResource : IDisposable
   {
     private readonly CResGFF resGff;
     private readonly CResStruct rootStruct;
@@ -21,16 +21,37 @@ namespace Anvil.API
       }
     }
 
+    ~GffResource()
+    {
+      Dispose(false);
+    }
+
     public string FileType { get; }
 
-    public GffResourceField this[uint index]
+    public GffResourceField this[int index]
     {
-      get => GffResourceField.Create(resGff, rootStruct, index);
+      get => GffResourceField.Create(resGff, rootStruct, (uint)index);
     }
 
     public GffResourceField this[string index]
     {
       get => GffResourceField.Create(resGff, rootStruct, index);
+    }
+
+    public void Dispose()
+    {
+      Dispose(true);
+    }
+
+    private void Dispose(bool disposing)
+    {
+      resGff?.Dispose();
+      rootStruct?.Dispose();
+
+      if (disposing)
+      {
+        GC.SuppressFinalize(this);
+      }
     }
   }
 }

--- a/src/main/Anvil/API/Resources/Gff/GffResource.cs
+++ b/src/main/Anvil/API/Resources/Gff/GffResource.cs
@@ -1,0 +1,36 @@
+using System;
+using NWN.Native.API;
+
+namespace Anvil.API
+{
+  public sealed class GffResource
+  {
+    private readonly CResGFF resGff;
+    private readonly CResStruct rootStruct;
+
+    internal GffResource(string name, CResGFF resGff)
+    {
+      this.resGff = resGff;
+
+      FileType = resGff.m_pFileType.ReadFixedLengthString();
+
+      rootStruct = new CResStruct();
+      if (!resGff.GetTopLevelStruct(rootStruct).ToBool())
+      {
+        throw new ArgumentException($"Failed to initialize top level structure in gff resource {name}", nameof(resGff));
+      }
+    }
+
+    public string FileType { get; }
+
+    public GffResourceField this[uint index]
+    {
+      get => GffResourceField.Create(resGff, rootStruct, index);
+    }
+
+    public GffResourceField this[string index]
+    {
+      get => GffResourceField.Create(resGff, rootStruct, index);
+    }
+  }
+}

--- a/src/main/Anvil/Services/ResourceManager/ResourceManager.cs
+++ b/src/main/Anvil/Services/ResourceManager/ResourceManager.cs
@@ -104,6 +104,12 @@ namespace Anvil.Services
       }
     }
 
+    /// <summary>
+    /// Gets the specified Gff resource.
+    /// </summary>
+    /// <param name="name">The resource name to fetch, without any filetype extensions.</param>
+    /// <param name="type">The type of the file/resource.</param>
+    /// <returns>A <see cref="GffResource"/> representation of the specified resource if it exists, otherwise null.</returns>
     public GffResource GetGenericFile(string name, ResRefType type)
     {
       CResRef resRef = new CResRef(name);

--- a/src/main/Anvil/Services/ResourceManager/ResourceManager.cs
+++ b/src/main/Anvil/Services/ResourceManager/ResourceManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using Anvil.API;
 using Anvil.Internal;
 using NLog;
@@ -80,7 +79,7 @@ namespace Anvil.Services
     /// <param name="name">The resource name to check.</param>
     /// <param name="type">The type of this resource.</param>
     /// <returns>true if the supplied resource exists and is of the specified type, otherwise false.</returns>
-    public unsafe bool IsValidResource(string name, ResRefType type = ResRefType.UTC)
+    public bool IsValidResource(string name, ResRefType type = ResRefType.UTC)
     {
       return ResMan.Exists(new CResRef(name), (ushort)type, null).ToBool();
     }
@@ -122,7 +121,7 @@ namespace Anvil.Services
     /// </summary>
     /// <param name="scriptName">The name of the script to get the contents of.</param>
     /// <returns>The script file contents or "" on error.</returns>
-    public unsafe string GetNSSContents(CExoString scriptName)
+    public string GetNSSContents(CExoString scriptName)
     {
       CScriptSourceFile scriptSourceFile = new CScriptSourceFile();
       byte* data;
@@ -161,7 +160,7 @@ namespace Anvil.Services
       return alias;
     }
 
-    private unsafe byte[] GetStandardResourceData(string name, ResRefType type)
+    private byte[] GetStandardResourceData(string name, ResRefType type)
     {
       if (TryGetNativeResource(name, type, out CRes res))
       {


### PR DESCRIPTION
Adds support for navigating Gff files in a LINQ-like way (XDocument/JSON.NET).

E.g:

```cs
    public GffTest(ResourceManager resourceManager)
    {
      GffResource palette = resourceManager.GetGenericFile("creaturepalcus", ResRefType.ITP);
      Log.Error(palette.FileType);

      Log.Error(palette["MAIN"][1]["LIST"][0]["FACTION"]); // Hostile
      Log.Error(palette["MAIN"][1]["LIST"][0]["NAME"]); // My Cool Creature
    }
```