### PR TITLE
Engine structures: explicitly define memory ownership

### DIFF
--- a/NWN.Anvil.Tests/NWN.Anvil.Tests.csproj
+++ b/NWN.Anvil.Tests/NWN.Anvil.Tests.csproj
@@ -40,6 +40,10 @@
       <ExcludeAssets>runtime</ExcludeAssets>
     </ProjectReference>
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="NWN.Native" Version="8193.34.2" PrivateAssets="compile" />
+  </ItemGroup>
 
   <ItemGroup>
     <ContentWithTargetPath Include="src\docker\**" TargetPath="..\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="Always" />

--- a/NWN.Anvil.Tests/NWN.Anvil.Tests.csproj.DotSettings
+++ b/NWN.Anvil.Tests/NWN.Anvil.Tests.csproj.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Capi_005Casync/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Capi_005Casync/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cmain_005Capi_005Cenginestructure/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/NWN.Anvil.Tests/src/main/API/EngineStructure/EffectTests.cs
+++ b/NWN.Anvil.Tests/src/main/API/EngineStructure/EffectTests.cs
@@ -24,6 +24,7 @@ namespace Anvil.Tests.API
 
       CGameEffect gameEffect = effect;
       Assert.IsNotNull(gameEffect, "Native effect was not valid after implicit cast.");
+
       Effect softReference = gameEffect.ToEffect(false);
       softReference.Dispose();
       Assert.IsTrue(softReference.IsValid, "The soft reference disposed the memory of the original effect.");

--- a/NWN.Anvil.Tests/src/main/API/EngineStructure/EffectTests.cs
+++ b/NWN.Anvil.Tests/src/main/API/EngineStructure/EffectTests.cs
@@ -1,0 +1,32 @@
+using Anvil.API;
+using NUnit.Framework;
+using NWN.Native.API;
+
+namespace Anvil.Tests.API
+{
+  [TestFixture(Category = "API.EngineStructure")]
+  public sealed class EffectTests
+  {
+    [Test(Description = "Creating an effect and disposing the effect explicitly frees the associated memory.")]
+    public void CreateAndDisposeEffectValidPropertyUpdated()
+    {
+      Effect effect = Effect.CutsceneParalyze();
+      Assert.IsTrue(effect.IsValid, "Effect was not valid after creation.");
+      effect.Dispose();
+      Assert.IsFalse(effect.IsValid, "Effect was still valid after disposing.");
+    }
+
+    [Test(Description = "A soft effect reference created from a native object does not cause the original effect to be deleted.")]
+    public void CreateSoftEffectReferencAndDisposeDoesNotFreeMemory()
+    {
+      Effect effect = Effect.Blindness();
+      Assert.IsTrue(effect.IsValid, "Effect was not valid after creation.");
+
+      CGameEffect gameEffect = effect;
+      Assert.IsNotNull(gameEffect, "Native effect was not valid after implicit cast.");
+      Effect softReference = gameEffect.ToEffect(false);
+      softReference.Dispose();
+      Assert.IsTrue(softReference.IsValid, "The soft reference disposed the memory of the original effect.");
+    }
+  }
+}

--- a/NWN.Anvil/src/main/API/EngineStructure/Cassowary.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/Cassowary.cs
@@ -5,7 +5,7 @@ namespace Anvil.API
 {
   public sealed class Cassowary : EngineStructure
   {
-    internal Cassowary(IntPtr handle) : base(handle) {}
+    internal Cassowary(IntPtr handle, bool memoryOwn) : base(handle, memoryOwn) {}
 
     /// <summary>
     /// Gets a printable debug state of this solver, which may help you debug complex systems.
@@ -16,7 +16,7 @@ namespace Anvil.API
 
     public static implicit operator Cassowary(IntPtr intPtr)
     {
-      return new Cassowary(intPtr);
+      return new Cassowary(intPtr, true);
     }
 
     /// <summary>

--- a/NWN.Anvil/src/main/API/EngineStructure/Effect.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/Effect.cs
@@ -6,7 +6,7 @@ namespace Anvil.API
 {
   public sealed partial class Effect : EffectBase
   {
-    internal Effect(CGameEffect effect) : base(effect) {}
+    internal Effect(CGameEffect effect, bool memoryOwn) : base(effect, memoryOwn) {}
 
     /// <summary>
     /// Gets the remaining duration of this effect in seconds. Returns 0 if the duration type is not <see cref="EffectDuration.Temporary"/>.
@@ -54,12 +54,12 @@ namespace Anvil.API
 
     public static explicit operator Effect(ItemProperty itemProperty)
     {
-      return new Effect(itemProperty);
+      return new Effect(itemProperty, true);
     }
 
     public static implicit operator Effect(IntPtr intPtr)
     {
-      return new Effect(CGameEffect.FromPointer(intPtr));
+      return new Effect(CGameEffect.FromPointer(intPtr), true);
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ namespace Anvil.API
       CGameEffect clone = new CGameEffect(true.ToInt());
       clone.CopyEffect(this, false.ToInt());
 
-      return new Effect(clone);
+      return new Effect(clone, true);
     }
   }
 }

--- a/NWN.Anvil/src/main/API/EngineStructure/EffectBase.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/EffectBase.cs
@@ -7,7 +7,7 @@ namespace Anvil.API
   {
     protected readonly CGameEffect Effect;
 
-    private protected unsafe EffectBase(CGameEffect effect) : base(effect.Pointer)
+    private protected unsafe EffectBase(CGameEffect effect, bool memoryOwn) : base(effect.Pointer, memoryOwn)
     {
       Effect = effect;
 

--- a/NWN.Anvil/src/main/API/EngineStructure/EngineStructure.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/EngineStructure.cs
@@ -8,7 +8,7 @@ namespace Anvil.API
   /// </summary>
   public abstract class EngineStructure : IDisposable
   {
-    private readonly IntPtr handle;
+    private IntPtr handle;
     private bool memoryOwn;
 
     private protected EngineStructure(IntPtr handle, bool memoryOwn)
@@ -29,8 +29,18 @@ namespace Anvil.API
 
     protected abstract int StructureId { get; }
 
+    /// <summary>
+    /// Gets if this object is valid.
+    /// </summary>
+    public bool IsValid => handle != IntPtr.Zero;
+
     public static implicit operator IntPtr(EngineStructure engineStructure)
     {
+      if (!engineStructure.IsValid)
+      {
+        throw new InvalidOperationException("Engine structure is not valid.");
+      }
+
       return engineStructure.handle;
     }
 
@@ -46,6 +56,7 @@ namespace Anvil.API
       {
         memoryOwn = false;
         VM.FreeGameDefinedStructure(StructureId, handle);
+        handle = IntPtr.Zero;
       }
     }
   }

--- a/NWN.Anvil/src/main/API/EngineStructure/EngineStructure.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/EngineStructure.cs
@@ -9,10 +9,17 @@ namespace Anvil.API
   public abstract class EngineStructure : IDisposable
   {
     private readonly IntPtr handle;
+    private bool memoryOwn;
 
-    private protected EngineStructure(IntPtr handle)
+    private protected EngineStructure(IntPtr handle, bool memoryOwn)
     {
       this.handle = handle;
+      this.memoryOwn = memoryOwn;
+
+      if (memoryOwn)
+      {
+        GC.SuppressFinalize(this);
+      }
     }
 
     ~EngineStructure()
@@ -35,7 +42,11 @@ namespace Anvil.API
 
     private void ReleaseUnmanagedResources()
     {
-      VM.FreeGameDefinedStructure(StructureId, handle);
+      if (memoryOwn)
+      {
+        memoryOwn = false;
+        VM.FreeGameDefinedStructure(StructureId, handle);
+      }
     }
   }
 }

--- a/NWN.Anvil/src/main/API/EngineStructure/Event.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/Event.cs
@@ -5,13 +5,13 @@ namespace Anvil.API
 {
   internal sealed class Event : EngineStructure
   {
-    internal Event(IntPtr handle) : base(handle) {}
+    internal Event(IntPtr handle, bool memoryOwn) : base(handle, memoryOwn) {}
 
     protected override int StructureId => NWScript.ENGINE_STRUCTURE_EVENT;
 
     public static implicit operator Event(IntPtr intPtr)
     {
-      return new Event(intPtr);
+      return new Event(intPtr, true);
     }
   }
 }

--- a/NWN.Anvil/src/main/API/EngineStructure/ItemProperty.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/ItemProperty.cs
@@ -6,7 +6,7 @@ namespace Anvil.API
 {
   public sealed partial class ItemProperty : EffectBase
   {
-    internal ItemProperty(CGameEffect effect) : base(effect) {}
+    internal ItemProperty(CGameEffect effect, bool memoryOwn) : base(effect, memoryOwn) {}
 
     /// <summary>
     /// Gets or sets the cost table to use for this item property.<br/>
@@ -116,12 +116,12 @@ namespace Anvil.API
 
     public static explicit operator ItemProperty(Effect effect)
     {
-      return new ItemProperty(effect);
+      return new ItemProperty(effect, true);
     }
 
     public static implicit operator ItemProperty(IntPtr intPtr)
     {
-      return new ItemProperty(CGameEffect.FromPointer(intPtr));
+      return new ItemProperty(CGameEffect.FromPointer(intPtr), true);
     }
   }
 }

--- a/NWN.Anvil/src/main/API/EngineStructure/Json.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/Json.cs
@@ -5,13 +5,13 @@ namespace Anvil.API
 {
   public sealed class Json : EngineStructure
   {
-    internal Json(IntPtr handle) : base(handle) {}
+    internal Json(IntPtr handle, bool memoryOwn) : base(handle, memoryOwn) {}
 
     protected override int StructureId => NWScript.ENGINE_STRUCTURE_JSON;
 
     public static implicit operator Json(IntPtr intPtr)
     {
-      return new Json(intPtr);
+      return new Json(intPtr, true);
     }
 
     public static Json Parse(string jsonString)

--- a/NWN.Anvil/src/main/API/EngineStructure/Location.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/Location.cs
@@ -7,7 +7,7 @@ namespace Anvil.API
 {
   public sealed class Location : EngineStructure
   {
-    internal Location(IntPtr handle) : base(handle) {}
+    internal Location(IntPtr handle, bool memoryOwn) : base(handle, memoryOwn) {}
 
     /// <summary>
     /// Gets the associated Area of this location.
@@ -78,7 +78,7 @@ namespace Anvil.API
 
     public static implicit operator Location(IntPtr intPtr)
     {
-      return new Location(intPtr);
+      return new Location(intPtr, true);
     }
 
     /// <summary>

--- a/NWN.Anvil/src/main/API/EngineStructure/SQLQuery.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/SQLQuery.cs
@@ -12,7 +12,7 @@ namespace Anvil.API
   {
     private bool executed;
     private bool hasResult;
-    internal SQLQuery(IntPtr handle) : base(handle) {}
+    internal SQLQuery(IntPtr handle, bool memoryOwn) : base(handle, memoryOwn) {}
 
     /// <summary>
     /// Returns "" if the last Sql command succeeded; or a human-readable error otherwise.
@@ -67,7 +67,7 @@ namespace Anvil.API
 
     public static implicit operator SQLQuery(IntPtr intPtr)
     {
-      return new SQLQuery(intPtr);
+      return new SQLQuery(intPtr, true);
     }
 
     /// <summary>

--- a/NWN.Anvil/src/main/API/EngineStructure/Talent.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/Talent.cs
@@ -5,7 +5,7 @@ namespace Anvil.API
 {
   public sealed partial class Talent : EngineStructure
   {
-    internal Talent(IntPtr handle) : base(handle) {}
+    internal Talent(IntPtr handle, bool memoryOwn) : base(handle, memoryOwn) {}
 
     /// <summary>
     /// Gets the associated feat, if this talent is a feat.
@@ -36,7 +36,7 @@ namespace Anvil.API
 
     public static implicit operator Talent(IntPtr intPtr)
     {
-      return new Talent(intPtr);
+      return new Talent(intPtr, true);
     }
 
     private int TryGetId(TalentType expectedType)

--- a/NWN.Anvil/src/main/API/Events/Native/DamageEvents/OnCreatureAttack.cs
+++ b/NWN.Anvil/src/main/API/Events/Native/DamageEvents/OnCreatureAttack.cs
@@ -70,19 +70,19 @@ namespace Anvil.API.Events
 
       private static OnCreatureAttack[] GetAttackEvents(void* pCreature, void* pTarget, int nAttacks)
       {
-        CNWSCreature cnwsCreature = CNWSCreature.FromPointer(pCreature);
-        NwCreature creature = cnwsCreature.ToNwObject<NwCreature>();
+        CNWSCreature creature = CNWSCreature.FromPointer(pCreature);
         NwGameObject target = CNWSObject.FromPointer(pTarget).ToNwObject<NwGameObject>();
+        NwCreature nwCreature = creature.ToNwObject<NwCreature>();
 
         // m_nCurrentAttack points to the attack after this flurry.
-        int attackNumberOffset = cnwsCreature.m_pcCombatRound.m_nCurrentAttack - nAttacks;
-        CNWSCombatRound combatRound = cnwsCreature.m_pcCombatRound;
+        int attackNumberOffset = creature.m_pcCombatRound.m_nCurrentAttack - nAttacks;
+        CNWSCombatRound combatRound = creature.m_pcCombatRound;
 
         // Create an event for each attack in the flurry
         OnCreatureAttack[] attackEvents = new OnCreatureAttack[nAttacks];
         for (int i = 0; i < nAttacks; i++)
         {
-          attackEvents[i] = GetEventData(creature, target, combatRound, attackNumberOffset + i);
+          attackEvents[i] = GetEventData(nwCreature, target, combatRound, attackNumberOffset + i);
         }
 
         return attackEvents;
@@ -116,6 +116,12 @@ namespace Anvil.API.Events
       [UnmanagedCallersOnly]
       private static void OnSignalMeleeDamage(void* pCreature, void* pTarget, int nAttacks)
       {
+        if (pCreature == null || pTarget == null)
+        {
+          signalMeleeDamageHook.CallOriginal(pCreature, pTarget, nAttacks);
+          return;
+        }
+
         OnCreatureAttack[] attackEvents = GetAttackEvents(pCreature, pTarget, nAttacks);
         foreach (OnCreatureAttack eventData in attackEvents)
         {
@@ -128,6 +134,12 @@ namespace Anvil.API.Events
       [UnmanagedCallersOnly]
       private static void OnSignalRangedDamage(void* pCreature, void* pTarget, int nAttacks)
       {
+        if (pCreature == null || pTarget == null)
+        {
+          signalRangedDamageHook.CallOriginal(pCreature, pTarget, nAttacks);
+          return;
+        }
+
         OnCreatureAttack[] attackEvents = GetAttackEvents(pCreature, pTarget, nAttacks);
         foreach (OnCreatureAttack eventData in attackEvents)
         {

--- a/NWN.Anvil/src/main/API/Events/Native/DamageEvents/OnCreatureDamage.cs
+++ b/NWN.Anvil/src/main/API/Events/Native/DamageEvents/OnCreatureDamage.cs
@@ -34,10 +34,14 @@ namespace Anvil.API.Events
       private static int OnApplyDamage(void* pEffectListHandler, void* pObject, void* pEffect, int bLoadingGame)
       {
         CNWSObject gameObject = CNWSObject.FromPointer(pObject);
+        CGameEffect effect = CGameEffect.FromPointer(pEffect);
+        if (gameObject == null || effect == null)
+        {
+          return Hook.CallOriginal(pEffectListHandler, pObject, pEffect, bLoadingGame);
+        }
+
         if (IsValidObjectTarget((ObjectType)gameObject.m_nObjectType))
         {
-          CGameEffect effect = CGameEffect.FromPointer(pEffect);
-
           ProcessEvent(new OnCreatureDamage
           {
             DamagedBy = effect.m_oidCreator.ToNwObject<NwObject>(),

--- a/NWN.Anvil/src/main/API/Events/Native/EffectEvents/OnCheckEffectImmunity.cs
+++ b/NWN.Anvil/src/main/API/Events/Native/EffectEvents/OnCheckEffectImmunity.cs
@@ -43,6 +43,11 @@ namespace Anvil.API.Events
       private static int OnGetEffectImmunity(void* pStats, byte nType, void* pVerses, int bConsiderFeats)
       {
         CNWSCreatureStats creatureStats = CNWSCreatureStats.FromPointer(pStats);
+        if (creatureStats == null)
+        {
+          return Hook.CallOriginal(pStats, nType, pVerses, bConsiderFeats);
+        }
+
         OnCheckEffectImmunity eventData = ProcessEvent(new OnCheckEffectImmunity
         {
           Creature = creatureStats.m_pBaseCreature.ToNwObject<NwCreature>(),

--- a/NWN.Anvil/src/main/API/Events/Native/EffectEvents/OnEffectApply.cs
+++ b/NWN.Anvil/src/main/API/Events/Native/EffectEvents/OnEffectApply.cs
@@ -58,7 +58,7 @@ namespace Anvil.API.Events
         OnEffectApply eventData = ProcessEvent(new OnEffectApply
         {
           Object = gameObject.ToNwObject(),
-          Effect = gameEffect.ToEffect(true),
+          Effect = gameEffect.ToEffect(false),
         });
 
         return eventData.PreventApply ? false.ToInt() : Hook.CallOriginal(pEffectListHandler, pObject, pEffect, bLoadingGame);

--- a/NWN.Anvil/src/main/API/Events/Native/EffectEvents/OnEffectRemove.cs
+++ b/NWN.Anvil/src/main/API/Events/Native/EffectEvents/OnEffectRemove.cs
@@ -58,7 +58,7 @@ namespace Anvil.API.Events
         OnEffectRemove eventData = ProcessEvent(new OnEffectRemove
         {
           Object = gameObject.ToNwObject(),
-          Effect = gameEffect.ToEffect(true),
+          Effect = gameEffect.ToEffect(false),
         });
 
         return eventData.PreventRemove ? false.ToInt() : Hook.CallOriginal(pEffectListHandler, pObject, pEffect);

--- a/NWN.Anvil/src/main/API/Extensions/NativeObjectExtensions.cs
+++ b/NWN.Anvil/src/main/API/Extensions/NativeObjectExtensions.cs
@@ -5,21 +5,15 @@ namespace Anvil.API
 {
   public static class NativeObjectExtensions
   {
-    public static Effect ToEffect(this CGameEffect effect, bool preventGc)
+    public static Effect ToEffect(this CGameEffect effect, bool memoryOwn)
     {
-      Effect retVal = effect != null && effect.Pointer != IntPtr.Zero ? new Effect(effect) : null;
-
-      if (retVal != null && preventGc)
-      {
-        GC.SuppressFinalize(effect);
-      }
-
+      Effect retVal = effect != null && effect.Pointer != IntPtr.Zero ? new Effect(effect, memoryOwn) : null;
       return retVal;
     }
 
-    public static ItemProperty ToItemProperty(this CGameEffect ipEffect)
+    public static ItemProperty ToItemProperty(this CGameEffect ipEffect, bool memoryOwn)
     {
-      return ipEffect != null && ipEffect.Pointer != IntPtr.Zero ? new ItemProperty(ipEffect) : null;
+      return ipEffect != null && ipEffect.Pointer != IntPtr.Zero ? new ItemProperty(ipEffect, memoryOwn) : null;
     }
 
     public static T ToNwObject<T>(this ICGameObject gameObject) where T : NwObject


### PR DESCRIPTION
Resolves a rare crash where GC would run despite the object finalizer being suppressed with GC.SuppressFinalize():
```
I [2022/01/03 22:05:53.980] [Anvil.API.Effect] Prevent Gc = True, Running GC on Engine Structure
   Constructed from:  at Anvil.API.Effect..ctor(CGameEffect effect, Boolean preventGc)
   at Anvil.API.NativeObjectExtensions.ToEffect(CGameEffect effect, Boolean preventGc)
   at Anvil.API.Events.OnEffectRemove.Factory.OnEffectRemoved(Void* pEffectListHandler, Void* pObject, Void* pEffect)

I [22:05:53] [NWNX_DotNET] [DotNETExports.cpp:388] Freeing game structure at 0x0x555bab40dba0
 NWNX Signal Handler:
==============================================================
 NWNX 8193.34 (790a54b734) has crashed. Fatal error: Segmentation fault (11).
 Please file a bug at https://github.com/nwnxee/unified/issues
==============================================================
```