### PR TITLE
Set PC Killer to LastDamager when LastHostileActor is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ https://github.com/nwn-dotnet/Anvil/compare/v8193.34.2...HEAD
   - The CoreService composition root is defined in `AnvilServiceManager`.
   - AnvilCore is now "dumber", and simply passes signals to `AnvilServiceManager` and `VirtualMachineFunctionHandler`.
   - `AnvilServiceManager` merges service initialization in `AnvilCore`, with the container/composition root setup from `IContainerFactory`
+- `OnPlayerDeath.Killer` now tries to `GetLastDamager` when `GetLastHostileActor` is invalid.
 
 ### Deprecated
 - `NwGameObject.CreatureAppearanceType`. Use `NwCreature.Appearance` instead.

--- a/NWN.Anvil/src/main/API/Events/Game/ModuleEvents/ModuleEvents.OnPlayerDeath.cs
+++ b/NWN.Anvil/src/main/API/Events/Game/ModuleEvents/ModuleEvents.OnPlayerDeath.cs
@@ -17,7 +17,8 @@ namespace Anvil.API.Events
     {
       public OnPlayerDeath()
       {
-        Killer = NWScript.GetLastHostileActor(DeadPlayer.ControlledCreature).ToNwObject<NwGameObject>();
+        Killer = NWScript.GetLastHostileActor(DeadPlayer.ControlledCreature).ToNwObject<NwGameObject>()
+          ?? NWScript.GetLastDamager(DeadPlayer.ControlledCreature).ToNwObject<NwGameObject>();
       }
 
       /// <summary>


### PR DESCRIPTION
I noticed that the `Killer` reference is sometimes `null` and checked what the lexicon says about [GetLastHostileActor(object)](https://nwnlexicon.com/index.php?title=GetLastHostileActor)
> When damage is applied by a placeable using [EffectDamage](https://nwnlexicon.com/index.php?title=EffectDamage), this function returns OBJECT_INVALID, effectively clearing the last creature value. So, for example, on death, if this function returns an invalid creature, you can use [GetLastDamager](https://nwnlexicon.com/index.php?title=GetLastDamager) to identify the killer placeable. It is not known whether this works for traps.

I understand that messing with the Killer reference may be unpopular, but I couldn't find a way to call `GetLastDamager` myself so I cooked up a suggestion. Please let me know if you think this is a bad idea.