### PR TITLE
Fix Spell ID Interpretation

### DIFF
--- a/NWN.Anvil/src/main/API/EngineStructure/EffectBase.cs
+++ b/NWN.Anvil/src/main/API/EngineStructure/EffectBase.cs
@@ -78,8 +78,8 @@ namespace Anvil.API
     /// </summary>
     public NwSpell Spell
     {
-      get => NwSpell.FromSpellId((int)Effect.m_nSpellId);
-      set => Effect.m_nSpellId = value.Id;
+      get => NwSpell.FromSpellId(Effect.m_nSpellId.AsInt());
+      set => Effect.m_nSpellId = value.Id.AsUInt();
     }
 
     /// <summary>

--- a/NWN.Anvil/src/main/API/Extensions/IntegerExtensions.cs
+++ b/NWN.Anvil/src/main/API/Extensions/IntegerExtensions.cs
@@ -68,6 +68,26 @@ namespace Anvil.API
     }
 
     /// <summary>
+    /// Reinterprets the specified value as an unsigned int.
+    /// </summary>
+    /// <param name="value">The value to reinterpret.</param>
+    /// <returns>The reinterpreted value.</returns>
+    public static uint AsUInt(this int value)
+    {
+      return unchecked((uint)value);
+    }
+
+    /// <summary>
+    /// Reinterprets the specified value as an int.
+    /// </summary>
+    /// <param name="value">The value to reinterpret.</param>
+    /// <returns>The reinterpreted value.</returns>
+    public static int AsInt(this uint value)
+    {
+      return unchecked((int)value);
+    }
+
+    /// <summary>
     /// Reinterprets the specified value as a boolean.
     /// </summary>
     /// <param name="value">The value to reinterpret.</param>

--- a/NWN.Anvil/src/main/API/Object/CreatureClassInfo.cs
+++ b/NWN.Anvil/src/main/API/Object/CreatureClassInfo.cs
@@ -34,7 +34,7 @@ namespace Anvil.API
     /// <param name="spellLevel">The spell level for the spell to be added.</param>
     public void AddKnownSpell(NwSpell spell, byte spellLevel)
     {
-      classInfo.AddKnownSpell(spellLevel, spell.Id);
+      classInfo.AddKnownSpell(spellLevel, spell.Id.AsUInt());
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ namespace Anvil.API
     /// <param name="spell">The spell to clear.</param>
     public void ClearMemorizedKnownSpells(NwSpell spell)
     {
-      classInfo.ClearMemorizedKnownSpells(spell.Id);
+      classInfo.ClearMemorizedKnownSpells(spell.Id.AsUInt());
     }
 
     /// <summary>
@@ -119,7 +119,7 @@ namespace Anvil.API
     /// <param name="spell">The spell to remove.</param>
     public void RemoveKnownSpell(byte spellLevel, NwSpell spell)
     {
-      classInfo.RemoveKnownSpell(spellLevel, spell.Id);
+      classInfo.RemoveKnownSpell(spellLevel, spell.Id.AsUInt());
     }
 
     /// <summary>

--- a/NWN.Anvil/src/main/API/Object/MemorizedSpellSlot.cs
+++ b/NWN.Anvil/src/main/API/Object/MemorizedSpellSlot.cs
@@ -18,7 +18,7 @@ namespace Anvil.API
     public bool IsDomainSpell
     {
       get => classInfo.GetIsDomainSpell(spellLevel, spellSlot).ToBool();
-      set => classInfo.SetMemorizedSpellSlot(spellLevel, spellSlot, Spell.Id, value.ToInt(), (byte)MetaMagic);
+      set => classInfo.SetMemorizedSpellSlot(spellLevel, spellSlot, Spell.Id.AsUInt(), value.ToInt(), (byte)MetaMagic);
     }
 
     public bool IsPopulated => classInfo.GetMemorizedSpellInSlotDetails(spellLevel, spellSlot) != null;
@@ -32,13 +32,13 @@ namespace Anvil.API
     public MetaMagic MetaMagic
     {
       get => (MetaMagic)classInfo.GetMemorizedSpellInSlotMetaType(spellLevel, spellSlot);
-      set => classInfo.SetMemorizedSpellSlot(spellLevel, spellSlot, Spell.Id, IsDomainSpell.ToInt(), (byte)value);
+      set => classInfo.SetMemorizedSpellSlot(spellLevel, spellSlot, Spell.Id.AsUInt(), IsDomainSpell.ToInt(), (byte)value);
     }
 
     public NwSpell Spell
     {
       get => NwSpell.FromSpellId((int)classInfo.GetMemorizedSpellInSlot(spellLevel, spellSlot));
-      set => classInfo.SetMemorizedSpellSlot(spellLevel, spellSlot, value.Id, IsDomainSpell.ToInt(), (byte)MetaMagic);
+      set => classInfo.SetMemorizedSpellSlot(spellLevel, spellSlot, value.Id.AsUInt(), IsDomainSpell.ToInt(), (byte)MetaMagic);
     }
 
     public void ClearMemorizedSpell()

--- a/NWN.Anvil/src/main/API/Object/NwCreature.cs
+++ b/NWN.Anvil/src/main/API/Object/NwCreature.cs
@@ -901,7 +901,7 @@ namespace Anvil.API
     public async Task ActionCastFakeSpellAt(NwSpell spell, Location location, ProjectilePathType pathType = ProjectilePathType.Default)
     {
       await WaitForObjectContext();
-      NWScript.ActionCastFakeSpellAtLocation((int)spell.Id, location, (int)pathType);
+      NWScript.ActionCastFakeSpellAtLocation(spell.Id, location, (int)pathType);
     }
 
     /// <summary>
@@ -913,7 +913,7 @@ namespace Anvil.API
     public async Task ActionCastFakeSpellAt(NwSpell spell, NwGameObject target, ProjectilePathType pathType = ProjectilePathType.Default)
     {
       await WaitForObjectContext();
-      NWScript.ActionCastFakeSpellAtObject((int)spell.Id, target, (int)pathType);
+      NWScript.ActionCastFakeSpellAtObject(spell.Id, target, (int)pathType);
     }
 
     /// <summary>
@@ -1815,7 +1815,7 @@ namespace Anvil.API
     /// <param name="spell">The spell to check.</param>
     public bool HasSpellEffect(NwSpell spell)
     {
-      return NWScript.GetHasSpellEffect((int)spell.Id, this).ToBool();
+      return NWScript.GetHasSpellEffect(spell.Id, this).ToBool();
     }
 
     /// <summary>
@@ -1825,7 +1825,7 @@ namespace Anvil.API
     /// <returns>True if this creature can immediately cast the spell.</returns>
     public bool HasSpellUse(NwSpell spell)
     {
-      return NWScript.GetHasSpell((int)spell.Id, this) > 0;
+      return NWScript.GetHasSpell(spell.Id, this) > 0;
     }
 
     /// <summary>

--- a/NWN.Anvil/src/main/API/Object/NwCreature.cs
+++ b/NWN.Anvil/src/main/API/Object/NwCreature.cs
@@ -1285,7 +1285,7 @@ namespace Anvil.API
       CExoArrayListCNWSStatsSpellLikeAbility specialAbilities = Creature.m_pStats.m_pSpellLikeAbilityList;
       specialAbilities.Add(new CNWSStats_SpellLikeAbility
       {
-        m_nSpellId = ability.Spell.Id,
+        m_nSpellId = ability.Spell.Id.AsUInt(),
         m_bReadied = ability.Ready.ToInt(),
         m_nCasterLevel = ability.CasterLevel,
       });
@@ -2250,7 +2250,7 @@ namespace Anvil.API
       if (index < specialAbilities.Count)
       {
         CNWSStats_SpellLikeAbility specialAbility = specialAbilities[index];
-        specialAbility.m_nSpellId = ability.Spell.Id;
+        specialAbility.m_nSpellId = ability.Spell.Id.AsUInt();
         specialAbility.m_bReadied = ability.Ready.ToInt();
         specialAbility.m_nCasterLevel = ability.CasterLevel;
       }

--- a/NWN.Anvil/src/main/API/Ruleset/NwRuleset.cs
+++ b/NWN.Anvil/src/main/API/Ruleset/NwRuleset.cs
@@ -143,7 +143,7 @@ namespace Anvil.API
         NwSpell[] retVal = new NwSpell[spellArray.m_nNumSpells];
         for (int i = 0; i < retVal.Length; i++)
         {
-          retVal[i] = new NwSpell((uint)i, spellArray.GetSpell(i));
+          retVal[i] = new NwSpell(i, spellArray.GetSpell(i));
         }
 
         return retVal;

--- a/NWN.Anvil/src/main/API/Ruleset/NwSpell.cs
+++ b/NWN.Anvil/src/main/API/Ruleset/NwSpell.cs
@@ -12,7 +12,7 @@ namespace Anvil.API
   {
     private readonly CNWSpell spellInfo;
 
-    internal NwSpell(uint spellId, CNWSpell spellInfo)
+    internal NwSpell(int spellId, CNWSpell spellInfo)
     {
       Id = spellId;
       this.spellInfo = spellInfo;
@@ -134,9 +134,9 @@ namespace Anvil.API
     public string IconResRef => spellInfo.m_resrefIcon.ToString();
 
     /// <summary>
-    /// Gets the ID of this skill.
+    /// Gets the ID of this spell.
     /// </summary>
-    public uint Id { get; }
+    public int Id { get; }
 
     /// <summary>
     /// Gets the name of the script invoked when the spell impacts a target.<br/>


### PR DESCRIPTION
Speculative fix to resolve `Effect.Spell` returning null in some cases.