### PR TITLE
Implement NwArea.LoadScreen property

### DIFF
--- a/NWN.Anvil/src/main/API/Object/NwArea.cs
+++ b/NWN.Anvil/src/main/API/Object/NwArea.cs
@@ -204,6 +204,15 @@ namespace Anvil.API
     }
 
     /// <summary>
+    /// Gets or sets the load screen for this area.
+    /// </summary>
+    public LoadScreenTableEntry LoadScreen
+    {
+      get => NwGameTables.LoadScreenTable[Area.m_nLoadScreenID];
+      set => Area.m_nLoadScreenID = (ushort)value.RowIndex;
+    }
+
+    /// <summary>
     /// Gets or sets the area ambient color during night time.
     /// </summary>
     public Color MoonAmbientColor

--- a/NWN.Anvil/src/main/API/TwoDimArray/Tables/LoadScreenTableEntry.cs
+++ b/NWN.Anvil/src/main/API/TwoDimArray/Tables/LoadScreenTableEntry.cs
@@ -1,0 +1,26 @@
+namespace Anvil.API
+{
+  public sealed class LoadScreenTableEntry : ITwoDimArrayEntry
+  {
+    public int RowIndex { get; init; }
+
+    public string? Label { get; private set; }
+
+    public string? ScriptingName { get; private set; }
+
+    public string? BMPResRef { get; private set; }
+
+    public string? TileSet { get; private set; }
+
+    public StrRef? StrRef { get; private set; }
+
+    public void InterpretEntry(TwoDimArrayEntry entry)
+    {
+      Label = entry.GetString("Label");
+      ScriptingName = entry.GetString("ScriptingName");
+      BMPResRef = entry.GetString("BMPResRef");
+      TileSet = entry.GetString("TileSet");
+      StrRef = entry.GetStrRef("StrRef");
+    }
+  }
+}

--- a/NWN.Anvil/src/main/API/TwoDimArray/Tables/NwGameTables.Factory.cs
+++ b/NWN.Anvil/src/main/API/TwoDimArray/Tables/NwGameTables.Factory.cs
@@ -102,6 +102,7 @@ namespace Anvil.API
         BodyBagTable = GetTable<BodyBagTableEntry>(arrays.m_pBodyBagTable);
         EnvironmentPresetTable = GetTable<EnvironmentPreset>("environment.2da");
         LightColorTable = GetTable<LightColorTableEntry>(arrays.m_pLightColorTable);
+        LoadScreenTable = GetTable<LoadScreenTableEntry>("loadscreens.2da");
         ItemPropertyCostTables = GetTable<ItemPropertyCostTablesEntry>("iprp_costtable.2da");
         ItemPropertyParamTables = GetTable<ItemPropertyParamTablesEntry>("iprp_paramtable.2da");
         ItemPropertyItemMapTable = GetTable<ItemPropertyItemMapTableEntry>(arrays.m_pItemPropsTable);

--- a/NWN.Anvil/src/main/API/TwoDimArray/Tables/NwGameTables.cs
+++ b/NWN.Anvil/src/main/API/TwoDimArray/Tables/NwGameTables.cs
@@ -38,6 +38,11 @@ namespace Anvil.API
     public static TwoDimArray<LightColorTableEntry> LightColorTable { get; private set; } = null!;
 
     /// <summary>
+    /// Gets the loading screen table (loadscreens.2da)
+    /// </summary>
+    public static TwoDimArray<LoadScreenTableEntry> LoadScreenTable { get; private set; } = null!;
+
+    /// <summary>
     /// Gets the belt parts table (parts_belt.2da)
     /// </summary>
     public static TwoDimArray<PartsTableEntry> PartsBeltTable { get; private set; } = null!;


### PR DESCRIPTION
Uses a game table entry instead of a numeric index.