### PR TITLE
Add NwCreature.IsBartering property

### DIFF
--- a/NWN.Anvil/src/main/API/Object/NwCreature.cs
+++ b/NWN.Anvil/src/main/API/Object/NwCreature.cs
@@ -440,6 +440,11 @@ namespace Anvil.API
     public Inventory Inventory { get; }
 
     /// <summary>
+    /// Gets a value indicating whether this creature is currently bartering.
+    /// </summary>
+    public bool IsBartering => Creature.m_pBarterInfo?.m_bWindowOpen.ToBool() == true;
+
+    /// <summary>
     /// Gets a value indicating whether this creature is a dead NPC, dead PC, or dying PC.
     /// </summary>
     public bool IsDead => NWScript.GetIsDead(this).ToBool();


### PR DESCRIPTION
I also tried this prop on `NwPlayer`
```cs
    public bool IsBartering
    {
      get => LoginCreature?.Creature.m_pBarterInfo?.m_bWindowOpen.ToBool() == true;
    }
```
but it's the same pointer so the shortcut didn't make that much sense to me. Let me know if you need something different.