### PR TITLE
Remove null-forgiving operator from OnSpellCast props

### DIFF
--- a/NWN.Anvil/src/main/API/Events/Native/SpellEvents/OnSpellCast.cs
+++ b/NWN.Anvil/src/main/API/Events/Native/SpellEvents/OnSpellCast.cs
@@ -18,7 +18,7 @@ namespace Anvil.API.Events
 
     public bool IsInstantSpell { get; private init; }
 
-    public NwItem Item { get; private init; } = null!;
+    public NwItem? Item { get; private init; }
 
     public MetaMagic MetaMagic { get; private init; }
 
@@ -26,11 +26,11 @@ namespace Anvil.API.Events
 
     public ProjectilePathType ProjectilePathType { get; private init; }
 
-    public NwSpell Spell { get; private init; } = null!;
+    public NwSpell? Spell { get; private init; }
 
     public bool SpellCountered { get; private init; }
 
-    public NwObject TargetObject { get; private init; } = null!;
+    public NwObject? TargetObject { get; private init; }
 
     public Vector3 TargetPosition { get; private init; }
 


### PR DESCRIPTION
I got nullpointers on these when casting AoE spells, except for `Spell` but I assume that can also be null if the AoE is created without a spell reference. Was the null-forgiving operator used intentionally for some reason?

I also noticed that `Caster` and `Hook` has the null-forgiving operator but removing them has side-effects and I don't know what's correct so I left them alone.