### PR TITLE
Fix object and player hash codes

### DIFF
--- a/NWN.Anvil/src/main/API/Object/NwObject.cs
+++ b/NWN.Anvil/src/main/API/Object/NwObject.cs
@@ -260,7 +260,7 @@ namespace Anvil.API
 
     public override int GetHashCode()
     {
-      return (int)ObjectId;
+      return unchecked((int)ObjectId);
     }
 
     /// <summary>

--- a/NWN.Anvil/src/main/API/Object/NwPlayer.cs
+++ b/NWN.Anvil/src/main/API/Object/NwPlayer.cs
@@ -925,7 +925,7 @@ namespace Anvil.API
 
     public override int GetHashCode()
     {
-      return Player.Pointer.GetHashCode();
+      return player.Pointer.GetHashCode();
     }
 
     /// <summary>


### PR DESCRIPTION
Resolves an issue where an exception would be thrown when attempting to remove disconnected/invalid players from a hash-backed collection.