### PR TITLE
Restore event scripts on shutdown/reload.

### DIFF
--- a/NWN.Anvil/src/main/API/Events/Game/GameEventFactory.EventKey.cs
+++ b/NWN.Anvil/src/main/API/Events/Game/GameEventFactory.EventKey.cs
@@ -6,13 +6,13 @@ namespace Anvil.API.Events
   {
     private readonly struct EventKey : IEquatable<EventKey>
     {
-      private readonly EventScriptType eventScriptType;
-      private readonly uint gameObject;
+      public readonly EventScriptType EventScriptType;
+      public readonly uint GameObject;
 
       public EventKey(EventScriptType eventScriptType, uint gameObject)
       {
-        this.eventScriptType = eventScriptType;
-        this.gameObject = gameObject;
+        this.EventScriptType = eventScriptType;
+        this.GameObject = gameObject;
       }
 
       public static bool operator ==(EventKey left, EventKey right)
@@ -27,7 +27,7 @@ namespace Anvil.API.Events
 
       public bool Equals(EventKey other)
       {
-        return eventScriptType == other.eventScriptType && gameObject == other.gameObject;
+        return EventScriptType == other.EventScriptType && GameObject == other.GameObject;
       }
 
       public override bool Equals(object? obj)
@@ -37,7 +37,7 @@ namespace Anvil.API.Events
 
       public override int GetHashCode()
       {
-        return HashCode.Combine((int)eventScriptType, gameObject);
+        return HashCode.Combine((int)EventScriptType, GameObject);
       }
     }
   }

--- a/NWN.Anvil/src/main/API/Events/Game/GameEventFactory.cs
+++ b/NWN.Anvil/src/main/API/Events/Game/GameEventFactory.cs
@@ -9,7 +9,7 @@ namespace Anvil.API.Events
 {
   [ServiceBinding(typeof(IEventFactory))]
   [ServiceBinding(typeof(IScriptDispatcher))]
-  public sealed partial class GameEventFactory : IEventFactory<GameEventFactory.RegistrationData>, IScriptDispatcher
+  public sealed partial class GameEventFactory : IEventFactory<GameEventFactory.RegistrationData>, IScriptDispatcher, IDisposable
   {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
@@ -114,6 +114,15 @@ namespace Anvil.API.Events
       if (callOriginal && !string.IsNullOrWhiteSpace(existingScript))
       {
         originalCallLookup[new EventKey(eventType, nwObject)] = existingScript;
+      }
+    }
+
+    public void Dispose()
+    {
+      // Restore the original event scripts for subscribed objects.
+      foreach ((EventKey key, string script) in originalCallLookup)
+      {
+        NWScript.SetEventScript(key.GameObject, (int)key.EventScriptType, script);
       }
     }
   }


### PR DESCRIPTION
When performing a hot reload, event scripts are not restored to their initial values. This can cause a change in behaviour after the hot reload, as the original event scripts will no-longer be called.

This PR introduces a change to re-apply the event scripts in the game event factory's dispose.