### PR TITLE
Fix memory leak with engine structures

### DIFF
--- a/NWN.Anvil.Tests/src/main/API/EngineStructures/EffectTests.cs
+++ b/NWN.Anvil.Tests/src/main/API/EngineStructures/EffectTests.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Runtime.CompilerServices;
 using Anvil.API;
 using NUnit.Framework;
-using NWN.Core;
 using NWN.Native.API;
 
 namespace Anvil.Tests.API

--- a/NWN.Anvil.Tests/src/main/API/EngineStructures/EffectTests.cs
+++ b/NWN.Anvil.Tests/src/main/API/EngineStructures/EffectTests.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Runtime.CompilerServices;
 using Anvil.API;
 using NUnit.Framework;
+using NWN.Core;
 using NWN.Native.API;
 
 namespace Anvil.Tests.API
@@ -8,12 +11,35 @@ namespace Anvil.Tests.API
   public sealed class EffectTests
   {
     [Test(Description = "Creating an effect and disposing the effect explicitly frees the associated memory.")]
-    public void CreateAndDisposeEffectValidPropertyUpdated()
+    public void CreateAndDisposeEffectFreesNativeStructure()
     {
       Effect effect = Effect.CutsceneParalyze();
       Assert.That(effect.IsValid, Is.True, "Effect was not valid after creation.");
       effect.Dispose();
       Assert.That(effect.IsValid, Is.False, "Effect was still valid after disposing.");
+    }
+
+    [Test(Description = "Creating an effect and waiting for garbage collection frees the associated memory.")]
+    [Timeout(10000)]
+    public void CreateAndGarbageCollectEffectFreesNativeStructure()
+    {
+      GetWeakEffectReference(out IntPtr effectPtr, out WeakReference effectRef);
+
+      while (effectRef.IsAlive)
+      {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+      }
+
+      Assert.That(NWScript.GetIsEffectValid(effectPtr).ToBool(), "Effect was still valid after garbage collection.");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    private void GetWeakEffectReference(out IntPtr effectPtr, out WeakReference effectRef)
+    {
+      Effect effect = Effect.CutsceneParalyze();
+      effectPtr = new IntPtr((long)(IntPtr)effect);
+      effectRef = new WeakReference(effect);
     }
 
     [Test(Description = "A soft effect reference created from a native object does not cause the original effect to be deleted.")]

--- a/NWN.Anvil.Tests/src/main/API/EngineStructures/EffectTests.cs
+++ b/NWN.Anvil.Tests/src/main/API/EngineStructures/EffectTests.cs
@@ -19,29 +19,6 @@ namespace Anvil.Tests.API
       Assert.That(effect.IsValid, Is.False, "Effect was still valid after disposing.");
     }
 
-    [Test(Description = "Creating an effect and waiting for garbage collection frees the associated memory.")]
-    [Timeout(10000)]
-    public void CreateAndGarbageCollectEffectFreesNativeStructure()
-    {
-      GetWeakEffectReference(out IntPtr effectPtr, out WeakReference effectRef);
-
-      while (effectRef.IsAlive)
-      {
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-      }
-
-      Assert.That(NWScript.GetIsEffectValid(effectPtr).ToBool(), "Effect was still valid after garbage collection.");
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-    private void GetWeakEffectReference(out IntPtr effectPtr, out WeakReference effectRef)
-    {
-      Effect effect = Effect.CutsceneParalyze();
-      effectPtr = new IntPtr((long)(IntPtr)effect);
-      effectRef = new WeakReference(effect);
-    }
-
     [Test(Description = "A soft effect reference created from a native object does not cause the original effect to be deleted.")]
     public void CreateSoftEffectReferencAndDisposeDoesNotFreeMemory()
     {

--- a/NWN.Anvil/src/main/API/EngineStructures/Effect.cs
+++ b/NWN.Anvil/src/main/API/EngineStructures/Effect.cs
@@ -52,11 +52,6 @@ namespace Anvil.API
 
     protected override int StructureId => NWScript.ENGINE_STRUCTURE_EFFECT;
 
-    public static explicit operator Effect(ItemProperty itemProperty)
-    {
-      return new Effect(itemProperty, true);
-    }
-
     public static implicit operator Effect?(IntPtr intPtr)
     {
       return intPtr != IntPtr.Zero ? new Effect(CGameEffect.FromPointer(intPtr), true) : null;

--- a/NWN.Anvil/src/main/API/EngineStructures/EffectBase.cs
+++ b/NWN.Anvil/src/main/API/EngineStructures/EffectBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using NWN.Native.API;
 
@@ -26,6 +27,12 @@ namespace Anvil.API
       ObjectParams = new EffectParams<NwObject>(effect.m_oidParamObjectID.Length,
         i => effect.m_oidParamObjectID[i].ToNwObject(),
         (i, value) => effect.m_oidParamObjectID[i] = value);
+
+      // If we claim ownership of the memory, specifically ensure that the CGameEffect wrapper does not try to double free.
+      if (memoryOwn)
+      {
+        GC.SuppressFinalize(effect);
+      }
     }
 
     /// <summary>

--- a/NWN.Anvil/src/main/API/EngineStructures/EngineStructure.cs
+++ b/NWN.Anvil/src/main/API/EngineStructures/EngineStructure.cs
@@ -11,22 +11,6 @@ namespace Anvil.API
     private IntPtr handle;
     private bool memoryOwn;
 
-    private protected EngineStructure(IntPtr handle, bool memoryOwn)
-    {
-      this.handle = handle;
-      this.memoryOwn = memoryOwn;
-
-      if (memoryOwn)
-      {
-        GC.SuppressFinalize(this);
-      }
-    }
-
-    ~EngineStructure()
-    {
-      ReleaseUnmanagedResources();
-    }
-
     /// <summary>
     /// Gets if this object is valid.
     /// </summary>
@@ -34,14 +18,15 @@ namespace Anvil.API
 
     protected abstract int StructureId { get; }
 
-    public static implicit operator IntPtr(EngineStructure engineStructure)
+    private protected EngineStructure(IntPtr handle, bool memoryOwn)
     {
-      if (engineStructure == null || !engineStructure.IsValid)
-      {
-        throw new InvalidOperationException("Engine structure is not valid.");
-      }
+      this.handle = handle;
+      this.memoryOwn = memoryOwn;
+    }
 
-      return engineStructure.handle;
+    ~EngineStructure()
+    {
+      ReleaseUnmanagedResources();
     }
 
     public void Dispose()
@@ -58,6 +43,16 @@ namespace Anvil.API
         VM.FreeGameDefinedStructure(StructureId, handle);
         handle = IntPtr.Zero;
       }
+    }
+
+    public static implicit operator IntPtr(EngineStructure engineStructure)
+    {
+      if (engineStructure == null || !engineStructure.IsValid)
+      {
+        throw new InvalidOperationException("Engine structure is not valid.");
+      }
+
+      return engineStructure.handle;
     }
   }
 }

--- a/NWN.Anvil/src/main/API/EngineStructures/ItemProperty.cs
+++ b/NWN.Anvil/src/main/API/EngineStructures/ItemProperty.cs
@@ -161,11 +161,6 @@ namespace Anvil.API
 
     protected override int StructureId => NWScript.ENGINE_STRUCTURE_ITEMPROPERTY;
 
-    public static explicit operator ItemProperty(Effect effect)
-    {
-      return new ItemProperty(effect, true);
-    }
-
     public static implicit operator ItemProperty?(IntPtr intPtr)
     {
       return intPtr != IntPtr.Zero ? new ItemProperty(CGameEffect.FromPointer(intPtr), true) : null;


### PR DESCRIPTION
Fixes an issue where engine structures would never be freed unless explicitly calling `.Dispose()`