### PR TITLE
Fix EventScriptType in CallInfo.TryGetEvent

### DIFF
--- a/NWN.Anvil/src/main/API/Events/Game/GameEventFactory.cs
+++ b/NWN.Anvil/src/main/API/Events/Game/GameEventFactory.cs
@@ -20,6 +20,9 @@ namespace Anvil.API.Events
     [Inject]
     private Lazy<EventService>? EventService { get; init; }
 
+    [Inject]
+    private VirtualMachine VirtualMachine { get; init; } = null!;
+
     // Caches
     private readonly Dictionary<EventScriptType, Func<IEvent>> eventConstructorCache = new Dictionary<EventScriptType, Func<IEvent>>();
     private readonly Dictionary<Type, GameEventAttribute> eventInfoCache = new Dictionary<Type, GameEventAttribute>();
@@ -54,7 +57,7 @@ namespace Anvil.API.Events
       {
         if (originalCallLookup.TryGetValue(new EventKey(eventScriptType, oidSelf), out scriptName))
         {
-          NWScript.ExecuteScript(scriptName, oidSelf);
+          VirtualMachine.Execute(scriptName, oidSelf, eventScriptType);
         }
 
         EventService.Value.ProcessEvent(EventCallbackType.Before, value.Invoke());

--- a/NWN.Anvil/src/main/API/Utils/VirtualMachine.cs
+++ b/NWN.Anvil/src/main/API/Utils/VirtualMachine.cs
@@ -81,6 +81,16 @@ namespace Anvil.API
       virtualMachine.RunScript(scriptName.ToExoString(), target);
     }
 
+    internal void Execute(string scriptName, uint oid, EventScriptType eventScriptType, params (string ParamName, string ParamValue)[] scriptParams)
+    {
+      foreach ((string paramName, string paramValue) in scriptParams)
+      {
+        NWScript.SetScriptParam(paramName, paramValue);
+      }
+
+      virtualMachine.RunScript(scriptName.ToExoString(), oid, true.ToInt(), (int)eventScriptType);
+    }
+
     /// <summary>
     /// Executes the specified NWN script.
     /// If scriptName does not specify a compiled script, nothing happens.


### PR DESCRIPTION
This fixes an issue where an Event Hook will cause `CallInfo.TryGetEvent()` from a ScriptHandler to fail.

Fixed by preserving EventScriptType in ExecuteScript.

---

Example of a chest with tag `"mychest_tag"` and OnOpen event script `"mychest_onopen"`

```cs
/* Event Hook */
public void Init() {
  NwObject.FindObjectsWithTag<NwPlaceable>(
    "mychest_tag",
    "yourchest_tag",
  )
  .ToList()
  .ForEach(chest => { chest.OnOpen += DoTheFirstThing; });
}

/* Script Handler */
[ScriptHandler("mychest_onopen")]
private void OnOpenMyChest(CallInfo callInfo)
{
  if (!callInfo.TryGetEvent<PlaceableEvents.OnOpen>(out var eventData))
  {
    logger.Error("OnOpenMyChest: Failed to get event data"); // <-- This happens
    return;
  }

  DoTheSecondThing(eventData);
}
```