### PR TITLE
Log unobserved task exceptions instead of terminating.

### DIFF
--- a/NWN.Anvil/src/main/Services/Core/Logging/UnobservedTaskExceptionLogger.cs
+++ b/NWN.Anvil/src/main/Services/Core/Logging/UnobservedTaskExceptionLogger.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using NLog;
+
+namespace Anvil.Services
+{
+  [ServiceBindingOptions(InternalBindingPriority.High)]
+  internal class UnobservedTaskExceptionLogger : ICoreService
+  {
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    ~UnobservedTaskExceptionLogger()
+    {
+      Unregister();
+    }
+
+    void ICoreService.Init()
+    {
+      TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+    }
+
+    void ICoreService.Load() {}
+
+    void ICoreService.Shutdown()
+    {
+      Unregister();
+      GC.SuppressFinalize(this);
+    }
+
+    void ICoreService.Start() {}
+
+    void ICoreService.Unload() {}
+
+    private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+    {
+      Log.Error(e.Exception, "Task Exception");
+      e.SetObserved();
+    }
+
+    private void Unregister()
+    {
+      TaskScheduler.UnobservedTaskException -= OnUnobservedTaskException;
+    }
+  }
+}

--- a/NWN.Anvil/src/main/Services/Services/AnvilServiceManager.cs
+++ b/NWN.Anvil/src/main/Services/Services/AnvilServiceManager.cs
@@ -224,6 +224,7 @@ namespace Anvil.Services
       RegisterCoreService<NwServer>();
       RegisterCoreService<LoggerManager>();
       RegisterCoreService<UnhandledExceptionLogger>();
+      RegisterCoreService<UnobservedTaskExceptionLogger>();
       RegisterCoreService<InjectionService>();
       RegisterCoreService<ModuleLoadTracker>();
       RegisterCoreService<VirtualMachineFunctionHandler>();


### PR DESCRIPTION
Catches and logs uncaught exceptions raised in `async Task` methods, instead of terminating the server.