### PR TITLE
ItemProperty LimitUseByClass

### DIFF
--- a/NWN.Anvil/src/main/API/EngineStructures/ItemProperty.Create.cs
+++ b/NWN.Anvil/src/main/API/EngineStructures/ItemProperty.Create.cs
@@ -289,9 +289,15 @@ namespace Anvil.API
       return NWScript.ItemPropertyLimitUseByAlign((int)alignmentGroup)!;
     }
 
+    [Obsolete("Use the NwClass/IPClass overload instead.")]
     public static ItemProperty LimitUseByClass(IPClass classType)
     {
       return NWScript.ItemPropertyLimitUseByClass((int)classType)!;
+    }
+
+    public static ItemProperty LimitUseByClass(NwClass classType)
+    {
+      return NWScript.ItemPropertyLimitUseByClass(classType.Id)!;
     }
 
     [Obsolete("Use the NwRace/RacialType overload instead.")]


### PR DESCRIPTION
Updated ItemProperty LimitUseByClass to reference the NwClass directly instead of IPClass