### PR TITLE
ELC validation failure check on 4th level ability gain

### DIFF
--- a/NWN.Anvil/src/main/Services/ELC/EnforceLegalCharacterService.cs
+++ b/NWN.Anvil/src/main/Services/ELC/EnforceLegalCharacterService.cs
@@ -855,22 +855,19 @@ namespace Anvil.Services
         // Keep track of our ability values
         if (nLevel % 4 == 0)
         {
-          if (pLevelStats.m_nAbilityGain < nAbilityAtLevel.Length && pLevelStats.m_nAbilityGain >= 0)
+          if (pLevelStats.m_nAbilityGain < nAbilityAtLevel.Length)
           {
             nAbilityAtLevel[pLevelStats.m_nAbilityGain]++;
           }
-          else
+          else if (HandleValidationFailure(out int strRefFailure, new OnELCValidationFailure
           {
-            if (HandleValidationFailure(out int strRefFailure, new OnELCValidationFailure
-            {
-              Player = nwPlayer,
-              Type = ValidationFailureType.Character,
-              SubType = ValidationFailureSubType.AbilityPointBuySystemCalculation,
-              StrRef = StrRefCharacterInvalidAbilityScores,
-            }))
-            {
-              return strRefFailure;
-            }
+            Player = nwPlayer,
+            Type = ValidationFailureType.Character,
+            SubType = ValidationFailureSubType.AbilityPointBuySystemCalculation,
+            StrRef = StrRefCharacterInvalidAbilityScores,
+          }))
+          {
+            return strRefFailure;
           }
         }
 

--- a/NWN.Anvil/src/main/Services/ELC/EnforceLegalCharacterService.cs
+++ b/NWN.Anvil/src/main/Services/ELC/EnforceLegalCharacterService.cs
@@ -855,7 +855,23 @@ namespace Anvil.Services
         // Keep track of our ability values
         if (nLevel % 4 == 0)
         {
-          nAbilityAtLevel[pLevelStats.m_nAbilityGain]++;
+          if (pLevelStats.m_nAbilityGain < nAbilityAtLevel.Length && pLevelStats.m_nAbilityGain >= 0)
+          {
+            nAbilityAtLevel[pLevelStats.m_nAbilityGain]++;
+          }
+          else
+          {
+            if (HandleValidationFailure(out int strRefFailure, new OnELCValidationFailure
+            {
+              Player = nwPlayer,
+              Type = ValidationFailureType.Character,
+              SubType = ValidationFailureSubType.AbilityPointBuySystemCalculation,
+              StrRef = StrRefCharacterInvalidAbilityScores,
+            }))
+            {
+              return strRefFailure;
+            }
+          }
         }
 
         // Get the stat bonus from feats


### PR DESCRIPTION
Throws a validation failure if the PC did not gain an ability point every 4th level