### PR TITLE
Fix poor checks in AddItemProperty

### DIFF
--- a/NWN.Anvil/src/main/API/EngineStructures/ItemProperty.Create.cs
+++ b/NWN.Anvil/src/main/API/EngineStructures/ItemProperty.Create.cs
@@ -341,6 +341,12 @@ namespace Anvil.API
       return NWScript.ItemPropertyNoDamage()!;
     }
 
+    public static ItemProperty OnHitCastSpell(IPCastSpell spell, int casterLevel)
+    {
+      return NWScript.ItemPropertyOnHitCastSpell((int)spell, casterLevel)!;
+    }
+
+    [Obsolete("Use the OnHitCastSpell(IPCastSpell, int) overload instead.")]
     public static ItemProperty OnHitCastSpell(IPCastSpell spell, IPSpellLevel spellLevel)
     {
       return NWScript.ItemPropertyOnHitCastSpell((int)spell, (int)spellLevel)!;

--- a/NWN.Anvil/src/main/API/Objects/NwItem.cs
+++ b/NWN.Anvil/src/main/API/Objects/NwItem.cs
@@ -344,10 +344,10 @@ namespace Anvil.API
         case AddPropPolicy.IgnoreExisting:
           break;
         case AddPropPolicy.ReplaceExisting:
-          RemoveItemProperties(itemProperty.Property, ignoreSubType ? null : itemProperty.SubType, ignoreDuration ? null : itemProperty.DurationType, ignoreTag ? null : itemProperty.Tag);
+          RemoveItemProperties(itemProperty.Property, ignoreSubType ? null : itemProperty.SubType, ignoreDuration ? null : durationType, ignoreTag ? null : itemProperty.Tag);
           break;
         case AddPropPolicy.KeepExisting:
-          if (HasItemProperty(itemProperty.Property, ignoreSubType ? null : itemProperty.SubType, ignoreDuration ? null : itemProperty.DurationType, ignoreTag ? null : itemProperty.Tag))
+          if (HasItemProperty(itemProperty.Property, ignoreSubType ? null : itemProperty.SubType, ignoreDuration ? null : durationType, ignoreTag ? null : itemProperty.Tag))
           {
             return;
           }


### PR DESCRIPTION
This PR changes two things:

1. The `durationType` argument to `AddItemProperty` is now correctly evaluated as part of the Add Prop Policy. Without this change it allows duplicates, e.g. when adding Temporary spell effects:
![image](https://github.com/user-attachments/assets/9e789af7-3e32-4b87-bad7-3111d98bb75b)

2. The `spellLevel` agument to `OnHitCastSpell` has changed type from `IPSpellLevel` to `int`, to correctly reflect the argument type (ref https://nwnlexicon.com/index.php/ItemPropertyOnHitCastSpell).

(2) introduces a breaking change. I put it in here as I was changing code in this neighborhood, but let me know if you think it belongs in a separate PR and I will move it.