### PR TITLE
Add DamageIncrease method overload to support DamageBonus parameter

### DIFF
--- a/NWN.Anvil/src/main/API/EngineStructures/Effect.Create.cs
+++ b/NWN.Anvil/src/main/API/EngineStructures/Effect.Create.cs
@@ -245,6 +245,16 @@ namespace Anvil.API
     }
 
     /// <summary>
+    /// Creates an effect that applies a bonus to a specified damage type.
+    /// </summary>
+    /// <param name="bonus">The damage bonus to apply.</param>
+    /// <param name="damageType">The damage type to apply the bonus to.</param>
+    public static Effect DamageIncrease(DamageBonus bonus, DamageType damageType = DamageType.Magical)
+    {
+      return NWScript.EffectDamageIncrease((int) bonus, (int)damageType)!;
+    }
+
+    /// <summary>
     /// Creates an effect that resists a constant amount of damage from a physical attack with a certain magical power.
     /// </summary>
     /// <param name="amount">The damage to remove from each attack.</param>

--- a/NWN.Anvil/src/main/API/EngineStructures/Effect.Create.cs
+++ b/NWN.Anvil/src/main/API/EngineStructures/Effect.Create.cs
@@ -251,7 +251,7 @@ namespace Anvil.API
     /// <param name="damageType">The damage type to apply the bonus to.</param>
     public static Effect DamageIncrease(DamageBonus bonus, DamageType damageType = DamageType.Magical)
     {
-      return NWScript.EffectDamageIncrease((int) bonus, (int)damageType)!;
+      return NWScript.EffectDamageIncrease((int)bonus, (int)damageType)!;
     }
 
     /// <summary>


### PR DESCRIPTION
This should resolve issue #772 

No modifications on existing API happens and since the `Effect.Create` has no Unit Tests I didn't add any.