### PR TITLE
Fix LevelUpHenchman package argument

### DIFF
--- a/NWN.Anvil/src/main/API/Objects/NwCreature.cs
+++ b/NWN.Anvil/src/main/API/Objects/NwCreature.cs
@@ -2265,7 +2265,7 @@ namespace Anvil.API
     /// <returns>Returns the new level if successful, or 0 if the function fails.</returns>
     public int LevelUpHenchman(NwClass nwClass, PackageType package, bool spellsReady = false)
     {
-      return NWScript.LevelUpHenchman(this, nwClass.Id, (int)package, spellsReady.ToInt());
+      return NWScript.LevelUpHenchman(this, nwClass.Id, spellsReady.ToInt(), (int)package);
     }
 
     /// <summary>


### PR DESCRIPTION
NwCreature.LevelUpHenchman(NwClass, PackageType, bool spellsReady) forwarded its arguments to the native call in the wrong order. The engine's actual signature is:

    int LevelUpHenchman(object oCreature, int nClass, int bReadyAllSpells, int nPackage)

but the wrapper called it as:

    NWScript.LevelUpHenchman(this, nwClass.Id, (int)package, spellsReady.ToInt())

putting `package` in the bReadyAllSpells slot and `spellsReady` in the nPackage slot. Any non-default `package` was silently discarded — if it didn't happen to match a valid packages.2da row, the engine fell back to the first row matching nClass's ClassID (per LevelUpHenchman's documented "no match" behavior), i.e. the class's stock default package, regardless of what was passed in.

Swap the two arguments back into their correct positions.